### PR TITLE
Feature/Add BS test mod

### DIFF
--- a/CatCore/ChatCoreInstance.cs
+++ b/CatCore/ChatCoreInstance.cs
@@ -118,9 +118,15 @@ namespace CatCore
 			_container.RegisterInitializer<ITwitchAuthService>((service, context) => service.Initialize());
 
 			_container.Register<ITwitchHelixApiService, TwitchHelixApiService>(Reuse.Singleton, Made.Of(FactoryMethod.ConstructorWithResolvableArgumentsIncludingNonPublic));
+
+			// TODO: Interface registration
+			_container.Register<TwitchService>(Reuse.Singleton, Made.Of(FactoryMethod.ConstructorWithResolvableArgumentsIncludingNonPublic));
+
 			// Spin up internal web api service
 			_container.Resolve<IKittenApiService>();
 		}
+
+		public TwitchService TwitchService => _container.Resolve<TwitchService>();
 
 #if DEBUG
 		internal Container? Container => _container;

--- a/CatCore/Directory.Build.targets
+++ b/CatCore/Directory.Build.targets
@@ -108,7 +108,7 @@
 		<Message Text="Copying '$(OutputAssemblyName).dll' to '$(LibsDir)'." Importance="high" Condition="$(CanCopyToPlugins)"/>
 		<Copy SourceFiles="$(OutputAssemblyName).dll" DestinationFiles="$(LibsDir)\$(AssemblyName).dll" Condition="$(CanCopyToPlugins)"/>
 		<Copy SourceFiles="$(OutputAssemblyName).pdb" DestinationFiles="$(LibsDir)\$(AssemblyName).pdb" Condition="'$(CanCopyToPlugins)' == 'True' AND Exists('$(OutputAssemblyName).pdb')"/>
-		<Message Text="Copying '$(OutputAssemblyName).manifest' to '$(LibsDir)'." Importance="high" Condition="$(CanCopyToPlugins)"/>
+		<Message Text="Copying '$(OutputAssemblyName).manifest' to '$(PluginDir)'." Importance="high" Condition="$(CanCopyToPlugins)"/>
 		<Copy SourceFiles="manifest.json" DestinationFiles="$(PluginDir)\$(AssemblyName).manifest" Condition="'$(CanCopyToPlugins)' == 'True' AND Exists('$(OutputAssemblyName).pdb')"/>
 		<Warning Text="Beat Saber is running, restart the game to use the latest build." Condition="'$(IsRunning)' == 'True'"/>
 	</Target>

--- a/CatCore/Services/Twitch/TwitchService.cs
+++ b/CatCore/Services/Twitch/TwitchService.cs
@@ -1,0 +1,19 @@
+﻿using CatCore.Services.Twitch.Interfaces;
+using Serilog;
+
+namespace CatCore.Services.Twitch
+{
+	public class TwitchService
+	{
+		private readonly ILogger _logger;
+		private readonly ITwitchHelixApiService _twitchHelixApiService;
+
+		internal TwitchService(ILogger logger, ITwitchHelixApiService twitchHelixApiService)
+		{
+			_logger = logger;
+			_twitchHelixApiService = twitchHelixApiService;
+		}
+
+		public ITwitchHelixApiService HelixApiService => _twitchHelixApiService;
+	}
+}

--- a/CatCore/manifest.json
+++ b/CatCore/manifest.json
@@ -11,5 +11,8 @@
 	],
 	"links": {
 		"project-home": "https://github.com/ErisApps/ChatCore"
+	},
+	"conflictsWith": {
+		"ChatCore": "*"
 	}
 }

--- a/CatCoreTesterMod/CatCoreTesterMod.csproj
+++ b/CatCoreTesterMod/CatCoreTesterMod.csproj
@@ -1,0 +1,82 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<OutputType>Library</OutputType>
+		<LangVersion>8</LangVersion>
+		<Nullable>enable</Nullable>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<LocalRefsDir Condition="Exists('..\Refs')">..\Refs</LocalRefsDir>
+		<BeatSaberDir>$(LocalRefsDir)</BeatSaberDir>
+		<AppOutputBase>$(MSBuildProjectDirectory)\</AppOutputBase>
+		<AssemblyName>CatCoreTesterMod</AssemblyName>
+		<RootNamespace>CatCoreTesterMod</RootNamespace>
+		<Configurations>Debug;Develop;Release</Configurations>
+		<Platforms>AnyCPU</Platforms>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)' != 'Release' ">
+		<DebugType>full</DebugType>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+		<DebugType>pdbonly</DebugType>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="$(DefineConstants.Contains('CIBuild')) OR '$(NCrunch)' == '1'">
+		<DisableCopyToPlugins>True</DisableCopyToPlugins>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(NCrunch)' == '1'">
+		<DisableCopyToPlugins>True</DisableCopyToPlugins>
+		<DisableZipRelease>True</DisableZipRelease>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Reference Include="Main">
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="IPA.Loader">
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="BSML">
+			<HintPath>$(BeatSaberDir)\Plugins\BSML.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="CatCore">
+			<HintPath>$(BeatSaberDir)\Libs\CatCore.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="SiraUtil">
+			<HintPath>$(BeatSaberDir)\Plugins\SiraUtil.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="Zenject">
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="Zenject-usage">
+			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject-usage.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<EmbeddedResource Include="manifest.json" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="Directory.Build.props" Condition="Exists('Directory.Build.props')" />
+		<None Include="Directory.Build.targets" Condition="Exists('Directory.Build.targets')" />
+		<None Include="CatCoreTesterMod.csproj.user" Condition="Exists('CatCoreTesterMod.csproj.user')" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="BeatSaberModdingTools.Tasks" Version="1.3.2">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+</Project>

--- a/CatCoreTesterMod/Directory.Build.props
+++ b/CatCoreTesterMod/Directory.Build.props
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This file contains project properties used by the build. -->
+<Project>
+  <ItemGroup>
+    <SourceRoot Include="$(MSBuildThisFileDirectory)/"/>
+  </ItemGroup>
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <DisableCopyToPlugins>true</DisableCopyToPlugins>
+    <DisableZipRelease>true</DisableZipRelease>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(NCrunch)' == '1'">
+    <ContinuousIntegrationBuild>false</ContinuousIntegrationBuild>
+    <DisableCopyToPlugins>true</DisableCopyToPlugins>
+    <DisableZipRelease>true</DisableZipRelease>
+  </PropertyGroup>
+</Project>

--- a/CatCoreTesterMod/Directory.Build.targets
+++ b/CatCoreTesterMod/Directory.Build.targets
@@ -1,0 +1,101 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- This file contains the build tasks and targets for verifying the manifest, zipping Release builds,
+     and copying the plugin to to your Beat Saber folder. Only edit this if you know what you are doing. -->
+<Project>
+  <PropertyGroup>
+    <BuildTargetsVersion>2.0</BuildTargetsVersion>
+    <!--Set this to true if you edit this file to prevent automatic updates-->
+    <BuildTargetsModified>false</BuildTargetsModified>
+    <!--Output assembly path without extension-->
+    <OutputAssemblyName>$(OutputPath)$(AssemblyName)</OutputAssemblyName>
+    <!--Path to folder to be zipped. Needs to be relative to the project directory to work without changes to the 'BuildForCI' target.-->
+    <ArtifactDestination>$(OutputPath)Final</ArtifactDestination>
+    <ErrorOnMismatchedVersions Condition="'$(Configuration)' == 'Release'">True</ErrorOnMismatchedVersions>
+  </PropertyGroup>
+  <!--Build Targets-->
+  <!--Displays a warning if BeatSaberModdingTools.Tasks is not installed.-->
+  <Target Name="CheckBSMTInstalled" AfterTargets="BeforeBuild" Condition="'$(BSMTTaskAssembly)' == ''">
+    <Warning Text="The BeatSaberModdingTools.Tasks nuget package doesn't seem to be installed, advanced build targets will not work." />
+  </Target>
+  <!--Runs a build task to get info about the project used by later targets.-->
+  <Target Name="GetProjectInfo" AfterTargets="CheckBSMTInstalled" DependsOnTargets="CheckBSMTInstalled" Condition="'$(BSMTTaskAssembly)' != ''">
+    <Message Text="Using AssemblyVersion defined in project instead of 'Properties\AssemblyInfo.cs'" Importance="high" Condition="'$(AssemblyVersion)' != ''" />
+    <GetManifestInfo FailOnError="$(ErrorOnMismatchedVersions)">
+      <Output TaskParameter="PluginVersion" PropertyName="PluginVersion" />
+      <Output TaskParameter="BasePluginVersion" PropertyName="BasePluginVersion" />
+      <Output TaskParameter="GameVersion" PropertyName="GameVersion" />
+    </GetManifestInfo>
+    <PropertyGroup>
+      <AssemblyVersion>$(BasePluginVersion)</AssemblyVersion>
+      <FileVersion>$(BasePluginVersion)</FileVersion>
+      <InformationalVersion>$(BasePluginVersion)</InformationalVersion>
+    </PropertyGroup>
+    <GetCommitInfo ProjectDir="$(ProjectDir)">
+      <Output TaskParameter="CommitHash" PropertyName="CommitHash" />
+      <Output TaskParameter="Branch" PropertyName="Branch" />
+      <Output TaskParameter="Modified" PropertyName="GitModified" />
+    </GetCommitInfo>
+    <PropertyGroup>
+      <!--Build name for artifact/zip file-->
+      <ArtifactName>$(AssemblyName)</ArtifactName>
+      <ArtifactName Condition="'$(PluginVersion)' != ''">$(ArtifactName)-$(PluginVersion)</ArtifactName>
+      <ArtifactName Condition="'$(GameVersion)' != ''">$(ArtifactName)-bs$(GameVersion)</ArtifactName>
+      <ArtifactName Condition="'$(CommitHash)' != '' AND '$(CommitHash)' != 'local'">$(ArtifactName)-$(CommitHash)</ArtifactName>
+    </PropertyGroup>
+  </Target>
+  <!--Build target for Continuous Integration builds. Set up for GitHub Actions.-->
+  <Target Name="BuildForCI" AfterTargets="Build" DependsOnTargets="GetProjectInfo" Condition="'$(ContinuousIntegrationBuild)' == 'True' AND '$(BSMTTaskAssembly)' != ''">
+    <PropertyGroup>
+      <!--Set 'ArtifactName' if it failed before.-->
+      <ArtifactName Condition="'$(ArtifactName)' == ''">$(AssemblyName)</ArtifactName>
+    </PropertyGroup>
+    <Message Text="Building for CI" Importance="high" />
+    <Message Text="PluginVersion: $(PluginVersion), AssemblyVersion: $(AssemblyVersion), GameVersion: $(GameVersion)" Importance="high" />
+    <Message Text="::set-output name=filename::$(ArtifactName)" Importance="high" />
+    <Message Text="::set-output name=assemblyname::$(AssemblyName)" Importance="high" />
+    <Message Text="::set-output name=artifactpath::$(ProjectDir)$(ArtifactDestination)" Importance="high" />
+    <Message Text="Copying '$(OutputAssemblyName).dll' to '$(ProjectDir)$(ArtifactDestination)\Plugins\$(AssemblyName).dll'" Importance="high" />
+    <Copy SourceFiles="$(OutputAssemblyName).dll" DestinationFiles="$(ProjectDir)$(ArtifactDestination)\Plugins\$(AssemblyName).dll" />
+  </Target>
+  <!--Creates a BeatMods compliant zip file with the release.-->
+  <Target Name="ZipRelease" AfterTargets="Build" Condition="'$(DisableZipRelease)' != 'True' AND '$(Configuration)' == 'Release' AND '$(BSMTTaskAssembly)' != ''">
+    <PropertyGroup>
+      <!--Set 'ArtifactName' if it failed before.-->
+      <ArtifactName Condition="'$(ArtifactName)' == ''">$(AssemblyName)</ArtifactName>
+      <DestinationDirectory>$(OutDir)zip\</DestinationDirectory>
+    </PropertyGroup>
+    <ItemGroup>
+      <OldZips Include="$(DestinationDirectory)$(AssemblyName)*.zip"/>
+    </ItemGroup>
+    <Copy SourceFiles="$(OutputAssemblyName).dll" DestinationFiles="$(ArtifactDestination)\Plugins\$(AssemblyName).dll" />
+    <Message Text="PluginVersion: $(PluginVersion), AssemblyVersion: $(AssemblyVersion), GameVersion: $(GameVersion)" Importance="high" />
+    <Delete Files="@(OldZips)" TreatErrorsAsWarnings="true" ContinueOnError="true" />
+    <ZipDir SourceDirectory="$(ArtifactDestination)" DestinationFile="$(DestinationDirectory)$(ArtifactName).zip" />
+  </Target>
+  <!--Copies the assembly and pdb to the Beat Saber folder.-->
+  <Target Name="CopyToPlugins" AfterTargets="Build" Condition="'$(DisableCopyToPlugins)' != 'True' AND '$(ContinuousIntegrationBuild)' != 'True'">
+    <PropertyGroup>
+      <PluginDir>$(BeatSaberDir)\Plugins</PluginDir>
+      <CanCopyToPlugins>True</CanCopyToPlugins>
+      <CopyToPluginsError Condition="!Exists('$(PluginDir)')">Unable to copy assembly to game folder, did you set 'BeatSaberDir' correctly in your 'csproj.user' file? Plugins folder doesn't exist: '$(PluginDir)'.</CopyToPluginsError>
+      <!--Error if 'BeatSaberDir' does not have 'Beat Saber.exe'-->
+      <CopyToPluginsError Condition="!Exists('$(BeatSaberDir)\Beat Saber.exe')">Unable to copy to Plugins folder, '$(BeatSaberDir)' does not appear to be a Beat Saber game install.</CopyToPluginsError>
+      <!--Error if 'BeatSaberDir' is the same as 'LocalRefsDir'-->
+      <CopyToPluginsError Condition="'$(BeatSaberDir)' == '$(LocalRefsDir)' OR '$(BeatSaberDir)' == ''">Unable to copy to Plugins folder, 'BeatSaberDir' has not been set in your 'csproj.user' file.</CopyToPluginsError>
+      <CanCopyToPlugins Condition="'$(CopyToPluginsError)' != ''">False</CanCopyToPlugins>
+    </PropertyGroup>
+    <!--Check if Beat Saber is running-->
+    <IsProcessRunning ProcessName="Beat Saber" Condition="'$(BSMTTaskAssembly)' != ''">
+      <Output TaskParameter="IsRunning" PropertyName="IsRunning" />
+    </IsProcessRunning>
+    <PropertyGroup>
+      <!--If Beat Saber is running, output to the Pending folder-->
+      <PluginDir Condition="'$(IsRunning)' == 'True'">$(BeatSaberDir)\IPA\Pending\Plugins</PluginDir>
+    </PropertyGroup>
+    <Warning Text="$(CopyToPluginsError)" Condition="'$(CopyToPluginsError)' != ''" />
+    <Message Text="Copying '$(OutputAssemblyName).dll' to '$(PluginDir)'." Importance="high" Condition="$(CanCopyToPlugins)" />
+    <Copy SourceFiles="$(OutputAssemblyName).dll" DestinationFiles="$(PluginDir)\$(AssemblyName).dll" Condition="$(CanCopyToPlugins)"  />
+    <Copy SourceFiles="$(OutputAssemblyName).pdb" DestinationFiles="$(PluginDir)\$(AssemblyName).pdb" Condition="'$(CanCopyToPlugins)' == 'True' AND Exists('$(OutputAssemblyName).pdb')"  />
+    <Warning Text="Beat Saber is running, restart the game to use the latest build." Condition="'$(IsRunning)' == 'True'" />
+  </Target>
+</Project>

--- a/CatCoreTesterMod/Installers/CatCoreInstaller.cs
+++ b/CatCoreTesterMod/Installers/CatCoreInstaller.cs
@@ -1,0 +1,28 @@
+﻿using CatCore;
+using CatCoreTesterMod.Services;
+using IPA.Logging;
+using SiraUtil;
+using SiraUtil.Zenject;
+using Zenject;
+
+namespace CatCoreTesterMod.Installers
+{
+	internal class CatCoreInstaller : Installer<Logger, ChatCoreInstance, CatCoreInstaller>
+	{
+		private readonly Logger _logger;
+		private readonly ChatCoreInstance _chatCoreInstance;
+
+		internal CatCoreInstaller(Logger logger, ChatCoreInstance chatCoreInstance)
+		{
+			_logger = logger;
+			_chatCoreInstance = chatCoreInstance;
+		}
+
+		public override void InstallBindings()
+		{
+			Container.BindLoggerAsSiraLogger(_logger);
+			Container.BindInstance(new UBinder<Plugin, ChatCoreInstance>(_chatCoreInstance)).AsSingle();
+			Container.BindInterfacesAndSelfTo<CatCoreTesterService>().AsSingle();
+		}
+	}
+}

--- a/CatCoreTesterMod/Plugin.cs
+++ b/CatCoreTesterMod/Plugin.cs
@@ -1,0 +1,35 @@
+﻿using CatCore;
+using CatCore.Logging;
+using CatCoreTesterMod.Installers;
+using IPA;
+using IPA.Logging;
+using SiraUtil.Zenject;
+using Zenject;
+
+namespace CatCoreTesterMod
+{
+	[Plugin(RuntimeOptions.DynamicInit)]
+	internal class Plugin
+	{
+		[Init]
+		public Plugin(Logger logger, Zenjector zenjector)
+		{
+			zenjector.OnApp<CatCoreInstaller>().WithParameters(logger, ChatCoreInstance.CreateInstance((level, context, message) => logger.GetChildLogger("CatCore").Log(level switch
+			{
+				CustomLogLevel.Trace => Logger.Level.Trace,
+				CustomLogLevel.Debug => Logger.Level.Debug,
+				CustomLogLevel.Information => Logger.Level.Info,
+				CustomLogLevel.Warning => Logger.Level.Warning,
+				CustomLogLevel.Error => Logger.Level.Error,
+				CustomLogLevel.Critical => Logger.Level.Critical,
+				_ => Logger.Level.Debug
+			}, $"{context} | {message}")));
+		}
+
+		[OnEnable, OnDisable]
+		public void OnState()
+		{
+			/* Plugin State Changed */
+		}
+	}
+}

--- a/CatCoreTesterMod/Services/CatCoreTesterService.cs
+++ b/CatCoreTesterMod/Services/CatCoreTesterService.cs
@@ -1,0 +1,35 @@
+﻿using System.Linq;
+using CatCore;
+using SiraUtil.Tools;
+using SiraUtil.Zenject;
+using Zenject;
+
+namespace CatCoreTesterMod.Services
+{
+	internal class CatCoreTesterService : IInitializable
+	{
+		private readonly SiraLog _logger;
+		private readonly ChatCoreInstance _chatCoreInstance;
+
+		public CatCoreTesterService(SiraLog logger, UBinder<Plugin, ChatCoreInstance> chatCoreInstance)
+		{
+			_logger = logger;
+			_chatCoreInstance = chatCoreInstance.Value;
+		}
+
+		public async void Initialize()
+		{
+			var userInfo = await _chatCoreInstance.TwitchService.HelixApiService.FetchUserInfo(loginNames: "realeris").ConfigureAwait(false);
+			if (userInfo != null)
+			{
+				var erisProfileData = userInfo.Value.Data.First();
+				_logger.Info($"Successfully requested info for user {erisProfileData.DisplayName}");
+			}
+			else
+			{
+				_logger.Warning("Something went wrong while trying to fetch the info of the requested user.");
+			}
+
+		}
+	}
+}

--- a/CatCoreTesterMod/manifest.json
+++ b/CatCoreTesterMod/manifest.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://raw.githubusercontent.com/bsmg/BSIPA-MetadataFileSchema/master/Schema.json",
+	"id": "CatCoreTesterMod",
+	"name": "CatCore Tester Mod",
+	"author": "Eris",
+	"version": "0.0.1-alpha",
+	"description": "A simple mod that has the sole purpose of testing CatCore in Beat Saber",
+	"gameVersion": "1.14.0",
+	"dependsOn": {
+		"BSIPA": "^4.1.6",
+		"SiraUtil": "^2.5.2",
+		"CatCore": "^0.0.1-alpha"
+	},
+	"conflictsWith": {
+		"ChatCore": "*"
+	}
+}

--- a/ChatCore.sln
+++ b/ChatCore.sln
@@ -6,6 +6,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CatCoreTester", "CatCoreTes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CatCoreStandaloneSandbox", "CatCoreStandaloneSandbox\CatCoreStandaloneSandbox.csproj", "{B07F1349-F895-4FEF-8FDF-A1531D612325}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CatCoreTesterMod", "CatCoreTesterMod\CatCoreTesterMod.csproj", "{202048B6-EDE6-479B-AE7F-135FEBD81C96}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -31,5 +33,11 @@ Global
 		{B07F1349-F895-4FEF-8FDF-A1531D612325}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B07F1349-F895-4FEF-8FDF-A1531D612325}.Develop|Any CPU.ActiveCfg = Develop|Any CPU
 		{B07F1349-F895-4FEF-8FDF-A1531D612325}.Develop|Any CPU.Build.0 = Develop|Any CPU
+		{202048B6-EDE6-479B-AE7F-135FEBD81C96}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{202048B6-EDE6-479B-AE7F-135FEBD81C96}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{202048B6-EDE6-479B-AE7F-135FEBD81C96}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{202048B6-EDE6-479B-AE7F-135FEBD81C96}.Release|Any CPU.Build.0 = Release|Any CPU
+		{202048B6-EDE6-479B-AE7F-135FEBD81C96}.Develop|Any CPU.ActiveCfg = Develop|Any CPU
+		{202048B6-EDE6-479B-AE7F-135FEBD81C96}.Develop|Any CPU.Build.0 = Develop|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This PR adds a test mod project to the solution with which the library can be tested in the context of Beat Saber.

The main differences between the existing CatCoreTester project and the newly added CatCoreTesterMod project are the following:
- The existing project has access to the internal methods and properties whereas the test mod does not.
- The existing project can directly consume the library (meaning that ILRepack does not have to run) whereas the test mod can only be used in combination with the ILRepacked library.