### PR TITLE
Bugfix/fixed various twitch auth bugs

### DIFF
--- a/CatCore/Services/KittenApiService.cs
+++ b/CatCore/Services/KittenApiService.cs
@@ -181,7 +181,7 @@ namespace CatCore.Services
 					response.ContentEncoding = Encoding.UTF8;
 					response.ContentType = "application/json";
 					await JsonSerializer
-						.SerializeAsync(response.OutputStream, new TwitchStateResponseDto(_twitchAuthService.IsValid, _twitchAuthService.LoggedInUser, userInfos, _settingsService.Config.TwitchConfig))
+						.SerializeAsync(response.OutputStream, new TwitchStateResponseDto(_twitchAuthService.TokenIsValid, _twitchAuthService.LoggedInUser, userInfos, _settingsService.Config.TwitchConfig))
 						.ConfigureAwait(false);
 
 					return true;
@@ -190,7 +190,7 @@ namespace CatCore.Services
 					using (_settingsService.ChangeTransaction())
 					{
 						var twitchConfig = _settingsService.Config.TwitchConfig;
-						if (_twitchAuthService.IsValid)
+						if (_twitchAuthService.TokenIsValid)
 						{
 							twitchConfig.OwnChannelEnabled = twitchStateRequestDto.SelfEnabled;
 							twitchConfig.AdditionalChannelsData = twitchStateRequestDto.AdditionalChannelsData;

--- a/CatCore/Services/KittenApiService.cs
+++ b/CatCore/Services/KittenApiService.cs
@@ -163,7 +163,6 @@ namespace CatCore.Services
 					if (code != null)
 					{
 						await _twitchAuthService.GetTokensByAuthorizationCode(code, request.Url.GetLeftPart(UriPartial.Path)).ConfigureAwait(false);
-						await _twitchAuthService.ValidateAccessToken().ConfigureAwait(false);
 					}
 
 					response.Redirect(request.Url.GetLeftPart(UriPartial.Authority));

--- a/CatCore/Services/Twitch/Interfaces/ITwitchAuthService.cs
+++ b/CatCore/Services/Twitch/Interfaces/ITwitchAuthService.cs
@@ -7,13 +7,14 @@ namespace CatCore.Services.Twitch.Interfaces
 	internal interface ITwitchAuthService : INeedAsyncInitialization
 	{
 		string? AccessToken { get; }
-		bool IsValid { get; }
+		bool HasTokens { get; }
+		bool TokenIsValid { get; }
 
 		ValidationResponse? LoggedInUser { get; }
 
 		string AuthorizationUrl(string redirectUrl);
 		Task<AuthorizationResponse?> GetTokensByAuthorizationCode(string authorizationCode, string redirectUrl);
-		Task<ValidationResponse?> ValidateAccessToken();
+		Task<ValidationResponse?> ValidateAccessToken(bool resetDataOnFailure = true);
 		Task<bool> RefreshTokens();
 		Task<bool> RevokeTokens();
 	}

--- a/CatCore/Services/Twitch/TwitchAuthService.cs
+++ b/CatCore/Services/Twitch/TwitchAuthService.cs
@@ -119,7 +119,7 @@ namespace CatCore.Services.Twitch
 			RefreshToken = authorizationResponse.Value.RefreshToken;
 			ValidUntil = authorizationResponse.Value.ExpiresIn;
 
-			Store();
+			await ValidateAccessToken().ConfigureAwait(false);
 
 			return authorizationResponse;
 		}

--- a/CatCore/Services/Twitch/TwitchAuthService.cs
+++ b/CatCore/Services/Twitch/TwitchAuthService.cs
@@ -194,7 +194,7 @@ namespace CatCore.Services.Twitch
 
 		public async Task<bool> RevokeTokens()
 		{
-			if (string.IsNullOrWhiteSpace(AccessToken))
+			if (string.IsNullOrWhiteSpace(RefreshToken))
 			{
 				return false;
 			}

--- a/CatCore/Services/Twitch/TwitchHelixApiService.cs
+++ b/CatCore/Services/Twitch/TwitchHelixApiService.cs
@@ -144,7 +144,7 @@ namespace CatCore.Services.Twitch
 			_logger.Verbose("Invoking Helix endpoint GET {Url}", url);
 #endif
 			// TODO: Validate that this doesn't have any unintended side-effects, maybe attempt token refresh beforehand
-			if (!_twitchAuthService.IsValid)
+			if (!_twitchAuthService.HasTokens)
 			{
 				_logger.Warning("Token not valid. Either the user is not logged in or the token has been revoked");
 				return null;
@@ -176,7 +176,7 @@ namespace CatCore.Services.Twitch
 			_logger.Verbose("Invoking Helix endpoint POST {Url}", url);
 #endif
 			// TODO: Validate that this doesn't have any unintended side-effects, maybe attempt token refresh beforehand
-			if (!_twitchAuthService.IsValid)
+			if (!_twitchAuthService.HasTokens)
 			{
 				_logger.Warning("Token not valid. Either the user is not logged in or the token has been revoked");
 				return null;

--- a/CatCore/Services/Twitch/TwitchHelixApiService.cs
+++ b/CatCore/Services/Twitch/TwitchHelixApiService.cs
@@ -143,10 +143,14 @@ namespace CatCore.Services.Twitch
 
 			_logger.Verbose("Invoking Helix endpoint GET {Url}", url);
 #endif
-			// TODO: Validate that this doesn't have any unintended side-effects, maybe attempt token refresh beforehand
 			if (!_twitchAuthService.HasTokens)
 			{
 				_logger.Warning("Token not valid. Either the user is not logged in or the token has been revoked");
+				return null;
+			}
+
+			if (!_twitchAuthService.TokenIsValid && !await _twitchAuthService.RefreshTokens().ConfigureAwait(false))
+			{
 				return null;
 			}
 
@@ -175,10 +179,14 @@ namespace CatCore.Services.Twitch
 
 			_logger.Verbose("Invoking Helix endpoint POST {Url}", url);
 #endif
-			// TODO: Validate that this doesn't have any unintended side-effects, maybe attempt token refresh beforehand
 			if (!_twitchAuthService.HasTokens)
 			{
 				_logger.Warning("Token not valid. Either the user is not logged in or the token has been revoked");
+				return null;
+			}
+
+			if (!_twitchAuthService.TokenIsValid && !await _twitchAuthService.RefreshTokens().ConfigureAwait(false))
+			{
 				return null;
 			}
 


### PR DESCRIPTION
Fixed a few bugs related to Twitch auth

- When the tokens had expired, they would be yeeted too early preventing the refresh logic from running successfully
- Fixed double credentials saving issue
- Fixed invalid null-check in RevokeTokens method
- Pro-actively try to refresh Twitch tokens when doing a Twitch Helix call 