### PR TITLE
Use precompiled version of DryIoc instead of source

### DIFF
--- a/CatCore/CatCore.csproj
+++ b/CatCore/CatCore.csproj
@@ -27,7 +27,7 @@
 	</PropertyGroup>
 
     <ItemGroup>
-		<PackageReference Include="DryIoc" Version="4.8.5" />
+		<PackageReference Include="DryIoc.dll" Version="4.8.5" />
 		<PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
 		<PackageReference Include="Polly" Version="7.2.2" />
 		<PackageReference Include="Serilog" Version="2.11.0-dev-01377" />

--- a/CatCore/ILRepack.targets
+++ b/CatCore/ILRepack.targets
@@ -22,6 +22,7 @@
 
 			<RepackInputAssemblies Include="CatCore.Shared.dll"/>
 			<RepackInputAssemblies Include="CatCore.Twemoji.dll"/>
+			<RepackInputAssemblies Include="DryIoc.dll"/>
 			<RepackInputAssemblies Include="Microsoft.Bcl.AsyncInterfaces.dll"/>
 			<RepackInputAssemblies Include="Polly.dll"/>
 			<RepackInputAssemblies Include="Serilog.dll"/>


### PR DESCRIPTION
This way, it can be marked as internal.