### PR TITLE
Bind server URL with wildcard

### DIFF
--- a/CatCore/ConstantsBase.cs
+++ b/CatCore/ConstantsBase.cs
@@ -6,7 +6,7 @@ namespace CatCore
 
 	internal abstract class ConstantsBase
 	{
-		internal static string InternalApiServerUri => "http://localhost:8338/";
+		internal static string InternalApiServerUri => "http://*:8338/";
 
 		internal abstract string CatCoreAuthServerUri { get; }
 


### PR DESCRIPTION
By binding with a wildcard, the web interface can be accessed through a user's network instead of only on their host machine.