### PR TITLE
Fix exception on conflicting BTTV emotes

### DIFF
--- a/CatCore/Services/Twitch/Media/BttvDataProvider.cs
+++ b/CatCore/Services/Twitch/Media/BttvDataProvider.cs
@@ -149,7 +149,7 @@ namespace CatCore.Services.Twitch.Media
 			{
 				if (CheckIfAnimated(emote, out var isAnimated))
 				{
-					parsedEmotes.Add(emote.Code, new ChatResourceData(type + "_" + emote.Id, emote.Code, "https://cdn.betterttv.net/emote/" + emote.Id + "/3x", isAnimated, type));
+					parsedEmotes[emote.Code] = new ChatResourceData(type + "_" + emote.Id, emote.Code, "https://cdn.betterttv.net/emote/" + emote.Id + "/3x", isAnimated, type);
 				}
 			}
 
@@ -169,7 +169,7 @@ namespace CatCore.Services.Twitch.Media
 					continue;
 				}
 
-				parsedEmotes.Add(emote.Code, new ChatResourceData(type + "_" + emote.Id, emote.Code, preferredUrl, false, type));
+				parsedEmotes[emote.Code] = new ChatResourceData(type + "_" + emote.Id, emote.Code, preferredUrl, false, type);
 			}
 
 			return new ReadOnlyDictionary<string, ChatResourceData>(parsedEmotes);


### PR DESCRIPTION
Apparently, it's possible for streamers to configure emotes that have conflicting codes.
This PR fixes the exception that was thrown by letting the last conflicting emote "win".
(Streamers should pay better attention to this and third party services basically shouldn't allow this behavior anyways)