### PR TITLE
Span-based multi-message deconstruction

### DIFF
--- a/CatCore/Helpers/IrcExtensions.cs
+++ b/CatCore/Helpers/IrcExtensions.cs
@@ -7,7 +7,7 @@ namespace CatCore.Helpers
 	internal static class IrcExtensions
 	{
 		// ReSharper disable once CognitiveComplexity
-		internal static void ParseIrcMessage(string messageInternal, out ReadOnlyDictionary<string, string>? tags, out string? prefix, out string commandType, out string? channelName,
+		internal static void ParseIrcMessage(ReadOnlySpan<char> messageAsSpan, out ReadOnlyDictionary<string, string>? tags, out string? prefix, out string commandType, out string? channelName,
 			out string? message)
 		{
 			// Null-ing this here as I can't do that in the method signature
@@ -21,8 +21,6 @@ namespace CatCore.Helpers
 
 			var position = 0;
 			int nextSpacePosition;
-
-			var messageAsSpan = messageInternal.AsSpan();
 
 			void SkipToNextNonSpaceCharacter(ref ReadOnlySpan<char> msg)
 			{

--- a/CatCore/Services/Twitch/TwitchIrcService.cs
+++ b/CatCore/Services/Twitch/TwitchIrcService.cs
@@ -41,8 +41,6 @@ namespace CatCore.Services.Twitch
 		private readonly ITwitchUserStateTrackerService _userStateTrackerService;
 		private readonly TwitchMediaDataProvider _twitchMediaDataProvider;
 
-		private readonly char[] _ircMessageSeparator = { '\r', '\n' };
-
 		private readonly Dictionary<string, string> _channelNameToChannelIdDictionary;
 
 		private readonly ConcurrentQueue<(string channelId, string message)> _messageQueue;

--- a/CatCoreBenchmarkSandbox/Benchmarks/TwitchIRCMessageDeconstruction/TwitchIrcMultiMessageCompoundDeconstructionBenchmark.cs
+++ b/CatCoreBenchmarkSandbox/Benchmarks/TwitchIRCMessageDeconstruction/TwitchIrcMultiMessageCompoundDeconstructionBenchmark.cs
@@ -34,14 +34,12 @@ namespace CatCoreBenchmarkSandbox.Benchmarks.TwitchIRCMessageDeconstruction
 				var startPosition = endPosition;
 				while (endPosition + 1 < rawMessagesAsSpan.Length)
 				{
-					if (rawMessagesAsSpan[endPosition] != '\r' && rawMessagesAsSpan[endPosition + 1] != '\n')
-					{
-						endPosition++;
-					}
-					else
+					if (rawMessagesAsSpan[endPosition] == '\r' && rawMessagesAsSpan[endPosition + 1] == '\n')
 					{
 						break;
 					}
+
+					endPosition++;
 				}
 
 				IrcExtensions.New.ParseIrcMessage(rawMessagesAsSpan.Slice(startPosition, endPosition - startPosition), out var tags, out var prefix, out var commandType, out var channelName,

--- a/CatCoreBenchmarkSandbox/Benchmarks/TwitchIRCMessageDeconstruction/TwitchIrcMultiMessageCompoundDeconstructionBenchmark.cs
+++ b/CatCoreBenchmarkSandbox/Benchmarks/TwitchIRCMessageDeconstruction/TwitchIrcMultiMessageCompoundDeconstructionBenchmark.cs
@@ -1,0 +1,382 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using BenchmarkDotNet.Attributes;
+
+namespace CatCoreBenchmarkSandbox.Benchmarks.TwitchIRCMessageDeconstruction
+{
+	public class TwitchIrcMultiMessageCompoundDeconstructionBenchmark
+	{
+		[Params(
+			":tmi.twitch.tv 001 realeris :Welcome, GLHF!\r\n:tmi.twitch.tv 002 realeris :Your host is tmi.twitch.tv\r\n:tmi.twitch.tv 003 realeris :This server is rather new\r\n:tmi.twitch.tv 004 realeris :-\r\n:tmi.twitch.tv 375 realeris :-\r\n:tmi.twitch.tv 372 realeris :You are in a maze of twisty passages, all alike.\r\n:tmi.twitch.tv 376 realeris :>\r\n@badge-info=;badges=;color=#FF69B4;display-name=RealEris;emote-sets=0,237026,489998,300374282,303670737,477339272,592920959,610186276;user-id=405499635;user-type= :tmi.twitch.tv GLOBALUSERSTATE\r\n")]
+		public string RawIrcMultiMessage = null!;
+
+		private readonly char[] _ircMessageSeparator = { '\r', '\n' };
+
+		[Benchmark(Baseline = true)]
+		public void OldBenchmark()
+		{
+			var messages = RawIrcMultiMessage.Split(_ircMessageSeparator, StringSplitOptions.RemoveEmptyEntries);
+			foreach (var messageInternal in messages)
+			{
+				// Handle IRC messages here
+				IrcExtensions.Old.ParseIrcMessage(messageInternal, out var tags, out var prefix, out var commandType, out var channelName, out var message);
+			}
+		}
+
+		[Benchmark]
+		public void NewBenchmark()
+		{
+			var rawMessagesAsSpan = RawIrcMultiMessage.AsSpan();
+			var endPosition = 0;
+			do
+			{
+				var startPosition = endPosition;
+				while (endPosition + 1 < rawMessagesAsSpan.Length)
+				{
+					if (rawMessagesAsSpan[endPosition] != '\r' && rawMessagesAsSpan[endPosition + 1] != '\n')
+					{
+						endPosition++;
+					}
+					else
+					{
+						break;
+					}
+				}
+
+				IrcExtensions.New.ParseIrcMessage(rawMessagesAsSpan.Slice(startPosition, endPosition - startPosition), out var tags, out var prefix, out var commandType, out var channelName,
+					out var message);
+
+				endPosition += 2;
+			} while (endPosition < rawMessagesAsSpan.Length);
+		}
+
+		internal static class IrcExtensions
+		{
+			internal static class Old
+			{
+				// ReSharper disable once CognitiveComplexity
+				internal static void ParseIrcMessage(string messageInternal, out ReadOnlyDictionary<string, string>? tags, out string? prefix, out string commandType, out string? channelName,
+					out string? message)
+				{
+					// Null-ing this here as I can't do that in the method signature
+					tags = null;
+					prefix = null;
+					channelName = null;
+					message = null;
+
+					// Twitch IRC Message spec
+					// https://ircv3.net/specs/extensions/message-tags
+
+					var position = 0;
+					int nextSpacePosition;
+
+					var messageAsSpan = messageInternal.AsSpan();
+
+					void SkipToNextNonSpaceCharacter(ref ReadOnlySpan<char> msg)
+					{
+						while (position < msg.Length && msg[position] == ' ')
+						{
+							position++;
+						}
+					}
+
+					// Check for message tags
+					if (messageAsSpan[0] == '@')
+					{
+						nextSpacePosition = messageAsSpan.IndexOf(' ');
+						if (nextSpacePosition == -1)
+						{
+							throw new Exception("Invalid IRC Message");
+						}
+
+						var tagsAsSpan = messageAsSpan.Slice(1, nextSpacePosition - 1);
+
+						var tagsDictInternal = new Dictionary<string, string>();
+
+						var charSeparator = '=';
+						var startPos = 0;
+						int curPos;
+
+						ReadOnlySpan<char> keyTmp = null;
+						for (curPos = 0; curPos < tagsAsSpan.Length; curPos++)
+						{
+							if (tagsAsSpan[curPos] == charSeparator)
+							{
+								if (charSeparator == ';')
+								{
+									if (curPos != startPos)
+									{
+										tagsDictInternal[keyTmp.ToString()] = tagsAsSpan.Slice(startPos, curPos - startPos).ToString();
+									}
+
+									charSeparator = '=';
+									startPos = curPos + 1;
+								}
+								else
+								{
+									keyTmp = tagsAsSpan.Slice(startPos, curPos - startPos);
+
+									charSeparator = ';';
+									startPos = curPos + 1;
+								}
+							}
+						}
+
+						if (curPos != startPos)
+						{
+							tagsDictInternal[keyTmp.ToString()] = tagsAsSpan.Slice(startPos, curPos - startPos).ToString();
+						}
+
+						tags = new ReadOnlyDictionary<string, string>(tagsDictInternal);
+
+						position = nextSpacePosition + 1;
+						SkipToNextNonSpaceCharacter(ref messageAsSpan);
+						messageAsSpan = messageAsSpan.Slice(position);
+						position = 0;
+					}
+
+
+					// Handle prefix
+					if (messageAsSpan[position] == ':')
+					{
+						nextSpacePosition = messageAsSpan.IndexOf(' ');
+						if (nextSpacePosition == -1)
+						{
+							throw new Exception("Invalid IRC Message");
+						}
+
+						prefix = messageAsSpan.Slice(1, (nextSpacePosition) - 1).ToString();
+
+						position = nextSpacePosition + 1;
+						SkipToNextNonSpaceCharacter(ref messageAsSpan);
+						messageAsSpan = messageAsSpan.Slice(position);
+						position = 0;
+					}
+
+
+					// Handle MessageType
+					nextSpacePosition = messageAsSpan.IndexOf(' ');
+					if (nextSpacePosition == -1)
+					{
+						if (messageAsSpan.Length > position)
+						{
+							commandType = messageAsSpan.ToString();
+							return;
+						}
+					}
+
+					commandType = messageAsSpan.Slice(0, nextSpacePosition).ToString();
+
+					position = nextSpacePosition + 1;
+					SkipToNextNonSpaceCharacter(ref messageAsSpan);
+					messageAsSpan = messageAsSpan.Slice(position);
+					position = 0;
+
+
+					// Handle channelname and message
+					var handledInLoop = false;
+					while (position < messageAsSpan.Length)
+					{
+						if (messageAsSpan[position] == ':')
+						{
+							handledInLoop = true;
+
+							// Handle message (extracting this first as we're going to do a lookback in order to determine the previous part)
+							message = messageAsSpan.Slice(position + 1).ToString();
+
+							// Handle everything before the colon as the channelname parameter
+							while (--position > 0 && messageAsSpan[position] == ' ')
+							{
+							}
+
+							if (position > 0)
+							{
+								var offset = messageAsSpan[0] == '#' ? 1 : 0;
+								channelName = messageAsSpan.Slice(offset, position + 1 - offset).ToString();
+							}
+
+							break;
+						}
+
+						position++;
+					}
+
+					if (handledInLoop)
+					{
+						return;
+					}
+
+					if (messageAsSpan[0] == '#')
+					{
+						messageAsSpan = messageAsSpan.Slice(1);
+					}
+
+					channelName = messageAsSpan.ToString();
+				}
+			}
+
+			internal static class New
+			{
+				// ReSharper disable once CognitiveComplexity
+				internal static void ParseIrcMessage(ReadOnlySpan<char> messageAsSpan, out ReadOnlyDictionary<string, string>? tags, out string? prefix, out string commandType,
+					out string? channelName,
+					out string? message)
+				{
+					// Null-ing this here as I can't do that in the method signature
+					tags = null;
+					prefix = null;
+					channelName = null;
+					message = null;
+
+					// Twitch IRC Message spec
+					// https://ircv3.net/specs/extensions/message-tags
+
+					var position = 0;
+					int nextSpacePosition;
+
+					void SkipToNextNonSpaceCharacter(ref ReadOnlySpan<char> msg)
+					{
+						while (position < msg.Length && msg[position] == ' ')
+						{
+							position++;
+						}
+					}
+
+					// Check for message tags
+					if (messageAsSpan[0] == '@')
+					{
+						nextSpacePosition = messageAsSpan.IndexOf(' ');
+						if (nextSpacePosition == -1)
+						{
+							throw new Exception("Invalid IRC Message");
+						}
+
+						var tagsAsSpan = messageAsSpan.Slice(1, nextSpacePosition - 1);
+
+						var tagsDictInternal = new Dictionary<string, string>();
+
+						var charSeparator = '=';
+						var startPos = 0;
+						int curPos;
+
+						ReadOnlySpan<char> keyTmp = null;
+						for (curPos = 0; curPos < tagsAsSpan.Length; curPos++)
+						{
+							if (tagsAsSpan[curPos] == charSeparator)
+							{
+								if (charSeparator == ';')
+								{
+									if (curPos != startPos)
+									{
+										tagsDictInternal[keyTmp.ToString()] = tagsAsSpan.Slice(startPos, curPos - startPos).ToString();
+									}
+
+									charSeparator = '=';
+									startPos = curPos + 1;
+								}
+								else
+								{
+									keyTmp = tagsAsSpan.Slice(startPos, curPos - startPos);
+
+									charSeparator = ';';
+									startPos = curPos + 1;
+								}
+							}
+						}
+
+						if (curPos != startPos)
+						{
+							tagsDictInternal[keyTmp.ToString()] = tagsAsSpan.Slice(startPos, curPos - startPos).ToString();
+						}
+
+						tags = new ReadOnlyDictionary<string, string>(tagsDictInternal);
+
+						position = nextSpacePosition + 1;
+						SkipToNextNonSpaceCharacter(ref messageAsSpan);
+						messageAsSpan = messageAsSpan.Slice(position);
+						position = 0;
+					}
+
+
+					// Handle prefix
+					if (messageAsSpan[position] == ':')
+					{
+						nextSpacePosition = messageAsSpan.IndexOf(' ');
+						if (nextSpacePosition == -1)
+						{
+							throw new Exception("Invalid IRC Message");
+						}
+
+						prefix = messageAsSpan.Slice(1, (nextSpacePosition) - 1).ToString();
+
+						position = nextSpacePosition + 1;
+						SkipToNextNonSpaceCharacter(ref messageAsSpan);
+						messageAsSpan = messageAsSpan.Slice(position);
+						position = 0;
+					}
+
+
+					// Handle MessageType
+					nextSpacePosition = messageAsSpan.IndexOf(' ');
+					if (nextSpacePosition == -1)
+					{
+						if (messageAsSpan.Length > position)
+						{
+							commandType = messageAsSpan.ToString();
+							return;
+						}
+					}
+
+					commandType = messageAsSpan.Slice(0, nextSpacePosition).ToString();
+
+					position = nextSpacePosition + 1;
+					SkipToNextNonSpaceCharacter(ref messageAsSpan);
+					messageAsSpan = messageAsSpan.Slice(position);
+					position = 0;
+
+
+					// Handle channelname and message
+					var handledInLoop = false;
+					while (position < messageAsSpan.Length)
+					{
+						if (messageAsSpan[position] == ':')
+						{
+							handledInLoop = true;
+
+							// Handle message (extracting this first as we're going to do a lookback in order to determine the previous part)
+							message = messageAsSpan.Slice(position + 1).ToString();
+
+							// Handle everything before the colon as the channelname parameter
+							while (--position > 0 && messageAsSpan[position] == ' ')
+							{
+							}
+
+							if (position > 0)
+							{
+								var offset = messageAsSpan[0] == '#' ? 1 : 0;
+								channelName = messageAsSpan.Slice(offset, position + 1 - offset).ToString();
+							}
+
+							break;
+						}
+
+						position++;
+					}
+
+					if (handledInLoop)
+					{
+						return;
+					}
+
+					if (messageAsSpan[0] == '#')
+					{
+						messageAsSpan = messageAsSpan.Slice(1);
+					}
+
+					channelName = messageAsSpan.ToString();
+				}
+			}
+		}
+	}
+}

--- a/CatCoreBenchmarkSandbox/Benchmarks/TwitchIRCMessageDeconstruction/TwitchIrcMultiMessageCompoundDeconstructionBenchmark.cs
+++ b/CatCoreBenchmarkSandbox/Benchmarks/TwitchIRCMessageDeconstruction/TwitchIrcMultiMessageCompoundDeconstructionBenchmark.cs
@@ -14,7 +14,7 @@ namespace CatCoreBenchmarkSandbox.Benchmarks.TwitchIRCMessageDeconstruction
 		private readonly char[] _ircMessageSeparator = { '\r', '\n' };
 
 		[Benchmark(Baseline = true)]
-		public void OldBenchmark()
+		public void IntermediateStringSplitBenchmark()
 		{
 			var messages = RawIrcMultiMessage.Split(_ircMessageSeparator, StringSplitOptions.RemoveEmptyEntries);
 			foreach (var messageInternal in messages)
@@ -25,7 +25,7 @@ namespace CatCoreBenchmarkSandbox.Benchmarks.TwitchIRCMessageDeconstruction
 		}
 
 		[Benchmark]
-		public void NewBenchmark()
+		public void InlineSpanBasedSplitBenchmark()
 		{
 			var rawMessagesAsSpan = RawIrcMultiMessage.AsSpan();
 			var endPosition = 0;

--- a/CatCoreBenchmarkSandbox/Program.cs
+++ b/CatCoreBenchmarkSandbox/Program.cs
@@ -39,7 +39,7 @@ namespace CatCoreBenchmarkSandbox
 				.AddLogger(ConsoleLogger.Default)
 				.AddExporter(BenchmarkReportExporter.Default, HtmlExporter.Default, MarkdownExporter.Console);
 
-			BenchmarkRunner.Run<Benchmarks.EmojiParser.EmojiParserBenchmark>(benchmarkConfiguration);
+			BenchmarkRunner.Run<Benchmarks.TwitchIRCMessageDeconstruction.TwitchIrcMultiMessageCompoundDeconstructionBenchmark>(benchmarkConfiguration);
 		}
 	}
 }

--- a/CatCoreTests/IrcExtensionsTests.cs
+++ b/CatCoreTests/IrcExtensionsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using CatCore.Helpers;
@@ -113,7 +114,7 @@ namespace CatCoreTests
 			// NOP
 
 			// Act
-			IrcExtensions.ParseIrcMessage(inputData, out var tags, out var prefix, out var commandType, out var channelName, out var message);
+			IrcExtensions.ParseIrcMessage(inputData.AsSpan(), out var tags, out var prefix, out var commandType, out var channelName, out var message);
 
 			// Assert
 			tags.Should().BeEquivalentTo(expectedTags);


### PR DESCRIPTION
This PR reworks the incoming IRC message handler by reducing GC pressure caused by unnecessary allocations.
The message handler could sometimes receive multiple IRC messages in a single raw message and was relying string-based splitting in order to be able to deconstruct singular IRC messages. This at the cost of short-lived string allocations and array allocations.

The new approach is span-based. This means that we create new `ReadOnlySpan<char>` wrappers that still point to the same memory block under the hood, given that those wrappers are `readonly ref struct`'s, they're much lighter on the GC than the old approach. It also makes sense to use the new approach as the `IrcExtensions.ParseIrcMessage(...)` method was already using those under the hood.

Other than having reduced GC pressure, it became overall faster, as can be seen in the resultset below.

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.1526 (21H2)
AMD Ryzen 9 3900X, 1 CPU, 24 logical and 12 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4470.0), X64 RyuJIT
  Job-CIRMVA : .NET 5.0.14 (5.0.1422.5710), X64 RyuJIT
  Job-NVAYXH : .NET 6.0.2 (6.0.222.6406), X64 RyuJIT
  Job-ZSFKTD : .NET Framework 4.8 (4.8.4470.0), X64 RyuJIT
  Job-XTWDPN : Mono 5.11.0 (Visual Studio), X86 
  Job-UGEEKR : Mono 6.13.0 (Visual Studio), X86 
  Job-LJOXDK : Mono 6.13.0 (Visual Studio), X86 


|                           Method |        Job |                Runtime |  RawIrcMultiMessage |     Mean |     Error |    StdDev | Ratio |  Gen 0 |  Gen 1 | Allocated |
|--------------------------------- |----------- |----------------------- |-------------------- |---------:|----------:|----------:|------:|-------:|-------:|----------:|
|    InlineSpanBasedSplitBenchmark | Job-CIRMVA |               .NET 5.0 | :tmi(...)TE [528] | 1.301 μs | 0.00094 μs | 0.0084 μs |  0.79 | 0.2728 |      - |   2,288 B |
| IntermediateStringSplitBenchmark | Job-CIRMVA |               .NET 5.0 | :tmi(...)TE [528] | 1.642 μs | 0.0123 μs | 0.0115 μs |  1.00 | 0.4501 | 0.0019 |   3,768 B |
|                                  |            |                        |                     |          |           |           |       |        |        |           |
| IntermediateStringSplitBenchmark | Job-NVAYXH |               .NET 6.0 | :tmi(...)TE [528] | 1.247 μs | 0.0057 μs | 0.0051 μs |  1.00 | 0.4501 | 0.0019 |   3,768 B |
|    InlineSpanBasedSplitBenchmark | Job-NVAYXH |               .NET 6.0 | :tmi(...)TE [528] | 1.274 μs | 0.0070 μs | 0.0065 μs |  1.02 | 0.2728 |      - |   2,288 B |
|                                  |            |                        |                     |          |           |           |       |        |        |           |
|    InlineSpanBasedSplitBenchmark | Job-ZSFKTD |   .NET Framework 4.7.2 | :tmi(...)TE [528] | 2.253 μs | 0.0094 μs | 0.0088 μs |  0.93 | 0.3929 |      - |   2,503 B |
| IntermediateStringSplitBenchmark | Job-ZSFKTD |   .NET Framework 4.7.2 | :tmi(...)TE [528] | 2.431 μs | 0.0121 μs | 0.0113 μs |  1.00 | 0.9727 | 0.0038 |   6,146 B |
|                                  |            |                        |                     |          |           |           |       |        |        |           |
|    InlineSpanBasedSplitBenchmark | Job-XTWDPN | Mono Unity 2019.4.28f1 | :tmi(...)TE [528] | 5.192 μs | 0.0258 μs | 0.0241 μs |  0.79 | 0.4883 |      - |         - |
| IntermediateStringSplitBenchmark | Job-XTWDPN | Mono Unity 2019.4.28f1 | :tmi(...)TE [528] | 6.596 μs | 0.0275 μs | 0.0257 μs |  1.00 | 1.3199 |      - |         - |
|                                  |            |                        |                     |          |           |           |       |        |        |           |
|    InlineSpanBasedSplitBenchmark | Job-UGEEKR |  Mono Unity 2021.2.0b4 | :tmi(...)TE [528] | 3.805 μs | 0.0124 μs | 0.0116 μs |  0.92 | 0.4349 |      - |         - |
| IntermediateStringSplitBenchmark | Job-UGEEKR |  Mono Unity 2021.2.0b4 | :tmi(...)TE [528] | 4.149 μs | 0.0164 μs | 0.0154 μs |  1.00 | 0.7553 |      - |         - |
|                                  |            |                        |                     |          |           |           |       |        |        |           |
|    InlineSpanBasedSplitBenchmark | Job-LJOXDK | Mono Unity 2022.1.0a12 | :tmi(...)TE [528] | 3.894 μs | 0.0156 μs | 0.0146 μs |  0.93 | 0.4349 |      - |         - |
| IntermediateStringSplitBenchmark | Job-LJOXDK | Mono Unity 2022.1.0a12 | :tmi(...)TE [528] | 4.179 μs | 0.0142 μs | 0.0133 μs |  1.00 | 0.7553 |      - |         - |