### PR TITLE
Deferred async token refresh at startup

### DIFF
--- a/CatCore/CatCoreInstance.cs
+++ b/CatCore/CatCoreInstance.cs
@@ -130,8 +130,6 @@ namespace CatCore
 
 			// Register Twitch-specific services
 			_container.Register<ITwitchAuthService, TwitchAuthService>(Reuse.Singleton);
-			// .GetAwaiter().GetResult() is being used on the Initialize method to ensure the user is actually logged in when credentials are present
-			// _container.RegisterInitializer<ITwitchAuthService>((service, _) => service.Initialize().GetAwaiter().GetResult());
 			_container.Register<ITwitchChannelManagementService, TwitchChannelManagementService>(Reuse.Singleton, Made.Of(FactoryMethod.ConstructorWithResolvableArgumentsIncludingNonPublic));
 			_container.Register<ITwitchHelixApiService, TwitchHelixApiService>(Reuse.Singleton, Made.Of(FactoryMethod.ConstructorWithResolvableArgumentsIncludingNonPublic));
 			_container.Register<ITwitchPubSubServiceManager, TwitchPubSubServiceManager>(Reuse.Singleton);

--- a/CatCore/CatCoreInstance.cs
+++ b/CatCore/CatCoreInstance.cs
@@ -131,7 +131,7 @@ namespace CatCore
 			// Register Twitch-specific services
 			_container.Register<ITwitchAuthService, TwitchAuthService>(Reuse.Singleton);
 			// .GetAwaiter().GetResult() is being used on the Initialize method to ensure the user is actually logged in when credentials are present
-			_container.RegisterInitializer<ITwitchAuthService>((service, _) => service.Initialize().GetAwaiter().GetResult());
+			// _container.RegisterInitializer<ITwitchAuthService>((service, _) => service.Initialize().GetAwaiter().GetResult());
 			_container.Register<ITwitchChannelManagementService, TwitchChannelManagementService>(Reuse.Singleton, Made.Of(FactoryMethod.ConstructorWithResolvableArgumentsIncludingNonPublic));
 			_container.Register<ITwitchHelixApiService, TwitchHelixApiService>(Reuse.Singleton, Made.Of(FactoryMethod.ConstructorWithResolvableArgumentsIncludingNonPublic));
 			_container.Register<ITwitchPubSubServiceManager, TwitchPubSubServiceManager>(Reuse.Singleton);

--- a/CatCore/Exceptions/NotAuthenticatedException.cs
+++ b/CatCore/Exceptions/NotAuthenticatedException.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using CatCore.Models.Shared;
+
+namespace CatCore.Exceptions
+{
+	public abstract class NotAuthenticatedException : Exception
+	{
+		private readonly PlatformType _platform;
+		public override string Message => $"Non valid credentials are present for platform {_platform:G}, make sure the user is logged in or try again later.";
+
+		protected NotAuthenticatedException(PlatformType platform)
+		{
+			_platform = platform;
+		}
+	}
+
+	public class TwitchNotAuthenticatedException : NotAuthenticatedException
+	{
+		public TwitchNotAuthenticatedException() : base(PlatformType.Twitch)
+		{
+		}
+	}
+}

--- a/CatCore/Models/Credentials/AuthenticationStatus.cs
+++ b/CatCore/Models/Credentials/AuthenticationStatus.cs
@@ -1,0 +1,9 @@
+﻿namespace CatCore.Models.Credentials
+{
+	public enum AuthenticationStatus
+	{
+		Initializing,
+		Unauthorized,
+		Authenticated
+	}
+}

--- a/CatCore/Services/KittenApiService.cs
+++ b/CatCore/Services/KittenApiService.cs
@@ -178,8 +178,10 @@ namespace CatCore.Services
 				case "state" when request.HttpMethod == "GET":
 					response.ContentEncoding = Encoding.UTF8;
 					response.ContentType = "application/json";
+
 					var loggedInUserInfo = await _twitchAuthService.FetchLoggedInUserInfoWithRefresh().ConfigureAwait(false);
 					var userInfos = await _twitchChannelManagementService.GetAllChannelsEnriched().ConfigureAwait(false);
+
 					await JsonSerializer
 						.SerializeAsync(response.OutputStream, new TwitchStateResponseDto(_twitchAuthService.TokenIsValid, loggedInUserInfo, userInfos, _settingsService.Config.TwitchConfig))
 						.ConfigureAwait(false);

--- a/CatCore/Services/KittenApiService.cs
+++ b/CatCore/Services/KittenApiService.cs
@@ -180,8 +180,9 @@ namespace CatCore.Services
 
 					response.ContentEncoding = Encoding.UTF8;
 					response.ContentType = "application/json";
+					var loggedInUserInfo = await _twitchAuthService.FetchLoggedInUserInfoWithRefresh().ConfigureAwait(false);
 					await JsonSerializer
-						.SerializeAsync(response.OutputStream, new TwitchStateResponseDto(_twitchAuthService.TokenIsValid, _twitchAuthService.LoggedInUser, userInfos, _settingsService.Config.TwitchConfig))
+						.SerializeAsync(response.OutputStream, new TwitchStateResponseDto(_twitchAuthService.TokenIsValid, loggedInUserInfo, userInfos, _settingsService.Config.TwitchConfig))
 						.ConfigureAwait(false);
 
 					return true;

--- a/CatCore/Services/KittenApiService.cs
+++ b/CatCore/Services/KittenApiService.cs
@@ -176,11 +176,10 @@ namespace CatCore.Services
 
 					return true;
 				case "state" when request.HttpMethod == "GET":
-					var userInfos = await _twitchChannelManagementService.GetAllChannelsEnriched().ConfigureAwait(false);
-
 					response.ContentEncoding = Encoding.UTF8;
 					response.ContentType = "application/json";
 					var loggedInUserInfo = await _twitchAuthService.FetchLoggedInUserInfoWithRefresh().ConfigureAwait(false);
+					var userInfos = await _twitchChannelManagementService.GetAllChannelsEnriched().ConfigureAwait(false);
 					await JsonSerializer
 						.SerializeAsync(response.OutputStream, new TwitchStateResponseDto(_twitchAuthService.TokenIsValid, loggedInUserInfo, userInfos, _settingsService.Config.TwitchConfig))
 						.ConfigureAwait(false);

--- a/CatCore/Services/KittenPlatformServiceManagerBase.cs
+++ b/CatCore/Services/KittenPlatformServiceManagerBase.cs
@@ -81,7 +81,7 @@ namespace CatCore.Services
 
 		public void Dispose()
 		{
-			if(IsRunning)
+			if (IsRunning)
 			{
 				// TODO: figure out how you want to handle this
 				_ = Stop(null!);

--- a/CatCore/Services/Twitch/Interfaces/ITwitchAuthService.cs
+++ b/CatCore/Services/Twitch/Interfaces/ITwitchAuthService.cs
@@ -1,19 +1,22 @@
 ﻿using System;
 using System.Threading.Tasks;
+using CatCore.Models.Credentials;
 using CatCore.Models.Twitch.OAuth;
 using CatCore.Services.Interfaces;
 
 namespace CatCore.Services.Twitch.Interfaces
 {
-	internal interface ITwitchAuthService : INeedAsyncInitialization
+	internal interface ITwitchAuthService
 	{
 		string? AccessToken { get; }
 		bool HasTokens { get; }
 		bool TokenIsValid { get; }
 
+		AuthenticationStatus Status { get; }
 		event Action? OnCredentialsChanged;
 
-		ValidationResponse? LoggedInUser { get; }
+		ValidationResponse? FetchLoggedInUserInfo();
+		Task<ValidationResponse?> FetchLoggedInUserInfoWithRefresh();
 
 		string AuthorizationUrl(string redirectUrl);
 		Task GetTokensByAuthorizationCode(string authorizationCode, string redirectUrl);

--- a/CatCore/Services/Twitch/Interfaces/ITwitchHelixApiService.cs
+++ b/CatCore/Services/Twitch/Interfaces/ITwitchHelixApiService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using CatCore.Exceptions;
 using CatCore.Models.Twitch.Helix.Responses;
 using CatCore.Models.Twitch.Helix.Responses.Badges;
 using CatCore.Models.Twitch.Helix.Responses.Bits.Cheermotes;
@@ -22,6 +23,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// <param name="loginNames">List of login names of the users for which you want to request data</param>
 		/// <param name="cancellationToken">CancellationToken that can be used to cancel the call</param>
 		/// <returns>Response containing userdata</returns>
+		/// <exception cref="TwitchNotAuthenticatedException">Gets thrown when the user isn't authenticated, either make sure the user is logged in or try again later.</exception>
 		/// <exception cref="ArgumentException">Gets thrown when validation regarding one of the arguments fails.</exception>
 		/// <remarks><a href="https://dev.twitch.tv/docs/api/reference#get-users">Check out the Twitch API Reference docs.</a></remarks>
 		Task<ResponseBase<UserData>?> FetchUserInfo(string[]? userIds = null, string[]? loginNames = null, CancellationToken cancellationToken = default);
@@ -36,6 +38,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// <param name="description">Description of or comments on the marker. Max length is 140 characters.</param>
 		/// <param name="cancellationToken">CancellationToken that can be used to cancel the call</param>
 		/// <returns>Response containing data regarding the created stream marker.</returns>
+		/// <exception cref="TwitchNotAuthenticatedException">Gets thrown when the user isn't authenticated, either make sure the user is logged in or try again later.</exception>
 		/// <exception cref="ArgumentException">Gets thrown when validation regarding one of the arguments fails.</exception>
 		/// <remarks><a href="https://dev.twitch.tv/docs/api/reference#create-stream-marker">Check out the Twitch API Reference docs.</a></remarks>
 		Task<ResponseBase<CreateStreamMarkerData>?> CreateStreamMarker(string userId, string? description = null, CancellationToken cancellationToken = default);
@@ -50,6 +53,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// <param name="continuationCursor">Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response</param>
 		/// <param name="cancellationToken">CancellationToken that can be used to cancel the call</param>
 		/// <returns>Response containing channels matching the provided query</returns>
+		/// <exception cref="TwitchNotAuthenticatedException">Gets thrown when the user isn't authenticated, either make sure the user is logged in or try again later.</exception>
 		/// <exception cref="ArgumentException">Gets thrown when validation regarding one of the arguments fails.</exception>
 		/// <remarks><a href="https://dev.twitch.tv/docs/api/reference#search-channels">Check out the Twitch API Reference docs.</a></remarks>
 		Task<ResponseBaseWithPagination<ChannelData>?> SearchChannels(string query, uint? limit = null, bool? liveOnly = null, string? continuationCursor = null,
@@ -63,7 +67,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// <param name="continuationCursor">Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response</param>
 		/// <param name="cancellationToken">CancellationToken that can be used to cancel the call</param>
 		/// <returns>Response containing data of 0, 1 or more more polls</returns>
-		/// <exception cref="Exception">Gets thrown when the user isn't logged in.</exception>
+		/// <exception cref="TwitchNotAuthenticatedException">Gets thrown when the user isn't authenticated, either make sure the user is logged in or try again later.</exception>
 		/// <exception cref="ArgumentException">Gets thrown when validation regarding one of the arguments fails.</exception>
 		/// <remarks><a href="https://dev.twitch.tv/docs/api/reference#get-polls">Check out the Twitch API Reference docs.</a></remarks>
 		Task<ResponseBaseWithPagination<PollData>?> GetPolls(List<string>? pollIds = null, uint? limit = null, string? continuationCursor = null, CancellationToken cancellationToken = default);
@@ -80,7 +84,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// <param name="channelPointsPerVote">Number of Channel Points required to vote once with Channel Points. Minimum: 1. Maximum: 1000000.</param>
 		/// <param name="cancellationToken">CancellationToken that can be used to cancel the call</param>
 		/// <returns>Response containing data of the newly created poll</returns>
-		/// <exception cref="Exception">Gets thrown when the user isn't logged in.</exception>
+		/// <exception cref="TwitchNotAuthenticatedException">Gets thrown when the user isn't authenticated, either make sure the user is logged in or try again later.</exception>
 		/// <exception cref="ArgumentException">Gets thrown when validation regarding one of the arguments fails.</exception>
 		/// <remarks><a href="https://dev.twitch.tv/docs/api/reference#create-poll">Check out the Twitch API Reference docs.</a></remarks>
 		Task<ResponseBase<PollData>?> CreatePoll(string title, List<string> choices, uint duration, bool? bitsVotingEnabled = null, uint? bitsPerVote = null,
@@ -98,7 +102,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// </param>
 		/// <param name="cancellationToken">CancellationToken that can be used to cancel the call</param>
 		/// <returns>Response containing data of the ended poll</returns>
-		/// <exception cref="Exception">Gets thrown when the user isn't logged in.</exception>
+		/// <exception cref="TwitchNotAuthenticatedException">Gets thrown when the user isn't authenticated, either make sure the user is logged in or try again later.</exception>
 		/// <exception cref="ArgumentException">Gets thrown when validation regarding one of the arguments fails.</exception>
 		/// <remarks><a href="https://dev.twitch.tv/docs/api/reference#end-poll">Check out the Twitch API Reference docs.</a></remarks>
 		Task<ResponseBase<PollData>?> EndPoll(string pollId, PollStatus pollStatus, CancellationToken cancellationToken = default);
@@ -112,7 +116,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// <param name="continuationCursor">Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response</param>
 		/// <param name="cancellationToken">CancellationToken that can be used to cancel the call</param>
 		/// <returns>Response containing data of 0, 1 or more more predictions</returns>
-		/// <exception cref="Exception">Gets thrown when the user isn't logged in.</exception>
+		/// <exception cref="TwitchNotAuthenticatedException">Gets thrown when the user isn't authenticated, either make sure the user is logged in or try again later.</exception>
 		/// <exception cref="ArgumentException">Gets thrown when validation regarding one of the arguments fails.</exception>
 		/// <remarks><a href="https://dev.twitch.tv/docs/api/reference#get-predictions">Check out the Twitch API Reference docs.</a></remarks>
 		Task<ResponseBaseWithPagination<PredictionData>?> GetPredictions(List<string>? predictionIds = null, uint? limit = null, string? continuationCursor = null,
@@ -130,7 +134,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// <param name="duration">Total duration for the Prediction (in seconds). Minimum: 1. Maximum: 1800.</param>
 		/// <param name="cancellationToken">CancellationToken that can be used to cancel the call</param>
 		/// <returns>Response containing data of the newly created prediction</returns>
-		/// <exception cref="Exception">Gets thrown when the user isn't logged in.</exception>
+		/// <exception cref="TwitchNotAuthenticatedException">Gets thrown when the user isn't authenticated, either make sure the user is logged in or try again later.</exception>
 		/// <exception cref="ArgumentException">Gets thrown when validation regarding one of the arguments fails.</exception>
 		/// <remarks><a href="https://dev.twitch.tv/docs/api/reference#create-prediction">Check out the Twitch API Reference docs.</a></remarks>
 		Task<ResponseBase<PredictionData>?> CreatePrediction(string title, List<string> outcomes, uint duration, CancellationToken cancellationToken = default);
@@ -150,7 +154,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// <param name="winningOutcomeId">Id of the winning outcome for the Prediction. This parameter is required if <paramref name="predictionStatus" /> is being set to <see cref="PredictionStatus.Resolved"/>.</param>
 		/// <param name="cancellationToken">CancellationToken that can be used to cancel the call</param>
 		/// <returns>Response containing data of the ended prediction</returns>
-		/// <exception cref="Exception">Gets thrown when the user isn't logged in.</exception>
+		/// <exception cref="TwitchNotAuthenticatedException">Gets thrown when the user isn't authenticated, either make sure the user is logged in or try again later.</exception>
 		/// <exception cref="ArgumentException">Gets thrown when validation regarding one of the arguments fails.</exception>
 		/// <remarks><a href="https://dev.twitch.tv/docs/api/reference#end-prediction">Check out the Twitch API Reference docs.</a></remarks>
 		Task<ResponseBase<PredictionData>?> EndPrediction(string predictionId, PredictionStatus predictionStatus, string? winningOutcomeId = null, CancellationToken cancellationToken = default);
@@ -162,7 +166,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// <param name="userId">Id of the channel for which to retrieve Cheermotes. When no userId is passed or null, it will return all globally available Cheermotes.</param>
 		/// <param name="cancellationToken">CancellationToken that can be used to cancel the call</param>
 		/// <returns>Response containing data of cheermotes</returns>
-		/// <exception cref="Exception">Gets thrown when the user isn't logged in.</exception>
+		/// <exception cref="TwitchNotAuthenticatedException">Gets thrown when the user isn't authenticated, either make sure the user is logged in or try again later.</exception>
 		/// <remarks><a href="https://dev.twitch.tv/docs/api/reference#get-cheermotes">Check out the Twitch API Reference docs.</a></remarks>
 		Task<ResponseBase<CheermoteGroupData>?> GetCheermotes(string? userId = null, CancellationToken cancellationToken = default);
 
@@ -171,6 +175,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// </summary>
 		/// <param name="cancellationToken">CancellationToken that can be used to cancel the call</param>
 		/// <returns>Response containing data of globally available custom chat badges</returns>
+		/// <exception cref="TwitchNotAuthenticatedException">Gets thrown when the user isn't authenticated, either make sure the user is logged in or try again later.</exception>
 		/// <remarks><a href="https://dev.twitch.tv/docs/api/reference#get-global-chat-badges">Check out the Twitch API Reference docs.</a></remarks>
 		Task<ResponseBase<BadgeData>?> GetGlobalBadges(CancellationToken cancellationToken = default);
 
@@ -181,6 +186,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// <param name="userId">Id of the channel for which to retrieve the custom chat badges.</param>
 		/// <param name="cancellationToken">CancellationToken that can be used to cancel the call</param>
 		/// <returns>Response containing data of custom chat badges</returns>
+		/// <exception cref="TwitchNotAuthenticatedException">Gets thrown when the user isn't authenticated, either make sure the user is logged in or try again later.</exception>
 		/// <remarks><a href="https://dev.twitch.tv/docs/api/reference#get-channel-chat-badges">Check out the Twitch API Reference docs.</a></remarks>
 		Task<ResponseBase<BadgeData>?> GetBadgesForChannel(string userId, CancellationToken cancellationToken = default);
 
@@ -192,7 +198,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// <param name="continuationCursor">Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response</param>
 		/// <param name="cancellationToken">CancellationToken that can be used to cancel the call</param>
 		/// <returns>Response containing data of 0, 1 or more more followed streams</returns>
-		/// <exception cref="Exception">Gets thrown when the user isn't logged in.</exception>
+		/// <exception cref="TwitchNotAuthenticatedException">Gets thrown when the user isn't authenticated, either make sure the user is logged in or try again later.</exception>
 		/// <exception cref="ArgumentException">Gets thrown when validation regarding one of the arguments fails.</exception>
 		/// <remarks><a href="https://dev.twitch.tv/docs/api/reference#get-followed-streams">Check out the Twitch API Reference docs.</a></remarks>
 		Task<ResponseBaseWithPagination<Stream>?> GetFollowedStreams(uint? limit = null, string? continuationCursor = null, CancellationToken cancellationToken = default);
@@ -214,6 +220,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// <param name="continuationCursorAfter">Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response</param>
 		/// <param name="cancellationToken">CancellationToken that can be used to cancel the call</param>
 		/// <returns>Response containing data of 0, 1 or more more active streams</returns>
+		/// <exception cref="TwitchNotAuthenticatedException">Gets thrown when the user isn't authenticated, either make sure the user is logged in or try again later.</exception>
 		/// <exception cref="ArgumentException">Gets thrown when validation regarding one of the arguments fails.</exception>
 		/// <remarks><a href="https://dev.twitch.tv/docs/api/reference#get-streams">Check out the Twitch API Reference docs.</a></remarks>
 		Task<ResponseBaseWithPagination<Stream>?> GetStreams(string[]? userIds = null, string[]? loginNames = null, string[]? gameIds = null, string[]? languages = null, uint? limit = null,
@@ -224,6 +231,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// </summary>
 		/// <param name="cancellationToken">CancellationToken that can be used to cancel the call</param>
 		/// <returns>Response containing data of globally available chat emotes</returns>
+		/// <exception cref="TwitchNotAuthenticatedException">Gets thrown when the user isn't authenticated, either make sure the user is logged in or try again later.</exception>
 		/// <remarks><a href="https://dev.twitch.tv/docs/api/reference#get-global-emotes">Check out the Twitch API Reference docs.</a></remarks>
 		public Task<ResponseBaseWithTemplate<GlobalEmote>?> GetGlobalEmotes(CancellationToken cancellationToken = default);
 
@@ -237,6 +245,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// <param name="userId">Id of the channel for which to retrieve the custom chat emotes.</param>
 		/// <param name="cancellationToken">CancellationToken that can be used to cancel the call</param>
 		/// <returns>Response containing data of custom chat emotes</returns>
+		/// <exception cref="TwitchNotAuthenticatedException">Gets thrown when the user isn't authenticated, either make sure the user is logged in or try again later.</exception>
 		/// <remarks><a href="https://dev.twitch.tv/docs/api/reference#get-channel-chat-badges">Check out the Twitch API Reference docs.</a></remarks>
 		public Task<ResponseBaseWithTemplate<ChannelEmote>?> GetChannelEmotes(string userId, CancellationToken cancellationToken = default);
 	}

--- a/CatCore/Services/Twitch/TwitchAuthService.cs
+++ b/CatCore/Services/Twitch/TwitchAuthService.cs
@@ -207,11 +207,11 @@ namespace CatCore.Services.Twitch
 			}
 
 			using var responseMessage = await _exceptionRetryPolicy
-				.ExecuteAsync(() =>
+				.ExecuteAsync(async () =>
 				{
 					using var requestMessage = new HttpRequestMessage(HttpMethod.Get, TWITCH_AUTH_BASEURL + "validate");
 					requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", AccessToken);
-					return _twitchAuthClient.SendAsync(requestMessage);
+					return await _twitchAuthClient.SendAsync(requestMessage).ConfigureAwait(false);
 				})
 				.ConfigureAwait(false);
 

--- a/CatCore/Services/Twitch/TwitchAuthService.cs
+++ b/CatCore/Services/Twitch/TwitchAuthService.cs
@@ -145,14 +145,19 @@ namespace CatCore.Services.Twitch
 						_logger.Information("Refreshing tokens");
 						await RefreshTokens().ConfigureAwait(false);
 					}
+
+					return _loggedInUser;
 				}
 				catch (HttpRequestException ex)
 				{
 					_logger.Error(ex, "An error occurred while trying to validate/refresh the Twitch tokens. Make sure an active internet connection is available");
 				}
 			}
+			else
+			{
+				_logger.Warning("No Twitch Credentials present");
+			}
 
-			_logger.Warning("No Twitch Credentials present");
 			return null;
 		}
 

--- a/CatCore/Services/Twitch/TwitchPubSubServiceExperimentalAgent.cs
+++ b/CatCore/Services/Twitch/TwitchPubSubServiceExperimentalAgent.cs
@@ -137,12 +137,13 @@ namespace CatCore.Services.Twitch
 					return;
 				}
 
-				if (!_twitchAuthService.HasTokens || !_twitchAuthService.LoggedInUser.HasValue)
+				if (!_twitchAuthService.HasTokens)
 				{
 					return;
 				}
 
-				if (!(_twitchAuthService.TokenIsValid || await _twitchAuthService.RefreshTokens().ConfigureAwait(false)))
+				var loggedInUser = await _twitchAuthService.FetchLoggedInUserInfoWithRefresh().ConfigureAwait(false);
+				if (loggedInUser == null)
 				{
 					return;
 				}

--- a/CatCore/Services/Twitch/TwitchPubSubServiceManager.Events.cs
+++ b/CatCore/Services/Twitch/TwitchPubSubServiceManager.Events.cs
@@ -33,7 +33,7 @@ namespace CatCore.Services.Twitch
 
 		private void SendListenRequestToAgentsInternal(string topic)
 		{
-			var selfUserId = _twitchAuthService.LoggedInUser?.UserId;
+			var selfUserId = _twitchAuthService.FetchLoggedInUserInfo()?.UserId;
 			if (CanRegisterTopicOnAllChannels(topic))
 			{
 				foreach (var twitchPubSubServiceExperimentalAgent in _activePubSubConnections)
@@ -49,7 +49,7 @@ namespace CatCore.Services.Twitch
 
 		private void SendAllCurrentTopicsToAgentInternal(string channelId, TwitchPubSubServiceExperimentalAgent agent)
 		{
-			var isSelfAgent =  _twitchAuthService.LoggedInUser?.UserId == channelId;
+			var isSelfAgent =  _twitchAuthService.FetchLoggedInUserInfo()?.UserId == channelId;
 			using var _ = Synchronization.Lock(_topicRegistrationLocker);
 			foreach (var topic in _topicsWithRegisteredCallbacks)
 			{
@@ -90,7 +90,7 @@ namespace CatCore.Services.Twitch
 
 		private void SendUnlistenRequestToAgentsInternal(string topic)
 		{
-			var selfUserId = _twitchAuthService.LoggedInUser?.UserId;
+			var selfUserId = _twitchAuthService.FetchLoggedInUserInfo()?.UserId;
 			if (CanRegisterTopicOnAllChannels(topic))
 			{
 				foreach (var twitchPubSubServiceExperimentalAgent in _activePubSubConnections)

--- a/CatCoreBenchmarkSandbox/Benchmarks/TwitchIRCMessageDeconstruction/TwitchIrcMultiMessageCompoundDeconstructionBenchmark.cs
+++ b/CatCoreBenchmarkSandbox/Benchmarks/TwitchIRCMessageDeconstruction/TwitchIrcMultiMessageCompoundDeconstructionBenchmark.cs
@@ -5,6 +5,8 @@ using BenchmarkDotNet.Attributes;
 
 namespace CatCoreBenchmarkSandbox.Benchmarks.TwitchIRCMessageDeconstruction
 {
+	[MemoryDiagnoser]
+	[CategoriesColumn, AllStatisticsColumn, BaselineColumn, MinColumn, Q1Column, MeanColumn, Q3Column, MaxColumn, MedianColumn]
 	public class TwitchIrcMultiMessageCompoundDeconstructionBenchmark
 	{
 		[Params(


### PR DESCRIPTION
This PR resolves the main thread blocking token refresh by making it deferred and off-thread.
New exception types `TwitchNotAuthenticatedException` with base `NotAuthenticatedException` were also introduced to more transparantly communicate to consumers that certain features aren't available (yet).

This PR affects the suite of Twitch modules/services as it basically affects the shared initialization logic for said platform:
- IRC
- PubSub
- Helix API

It's considered stable as far as my testing goes though.