### PR TITLE
Dependency updates

### DIFF
--- a/CatCore.Shared/CatCore.Shared.csproj
+++ b/CatCore.Shared/CatCore.Shared.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="System.Text.Json" Version="6.0.2" />
+      <PackageReference Include="System.Text.Json" Version="7.0.0-preview.1.22076.8" />
     </ItemGroup>
 
 </Project>

--- a/CatCore/CatCore.csproj
+++ b/CatCore/CatCore.csproj
@@ -30,7 +30,7 @@
 	</PropertyGroup>
 
     <ItemGroup>
-		<PackageReference Include="DryIoc.dll" Version="4.8.6" />
+		<PackageReference Include="DryIoc.dll" Version="4.8.7" />
 		<PackageReference Include="JetBrains.Annotations" Version="2022.1.0-eap3" />
 		<PackageReference Include="Polly" Version="7.2.3" />
 		<PackageReference Include="Serilog" Version="2.11.0-dev-01380" />

--- a/CatCore/CatCore.csproj
+++ b/CatCore/CatCore.csproj
@@ -37,7 +37,7 @@
 		<PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
 		<PackageReference Include="System.Net.Http.Json" Version="6.0.2-mauipre.1.22054.8" />
 		<PackageReference Include="System.Reactive" Version="5.0.0" />
-		<PackageReference Include="System.Text.Json" Version="6.0.2" />
+		<PackageReference Include="System.Text.Json" Version="7.0.0-preview.1.22076.8" />
 		<PackageReference Include="Websocket.Client" Version="4.4.43" />
     </ItemGroup>
 

--- a/CatCore/CatCore.csproj
+++ b/CatCore/CatCore.csproj
@@ -35,7 +35,7 @@
 		<PackageReference Include="Polly" Version="7.2.3" />
 		<PackageReference Include="Serilog" Version="2.11.0-dev-01380" />
 		<PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
-		<PackageReference Include="System.Net.Http.Json" Version="6.0.2-mauipre.1.22054.8" />
+		<PackageReference Include="System.Net.Http.Json" Version="7.0.0-preview.1.22076.8" />
 		<PackageReference Include="System.Reactive" Version="5.0.0" />
 		<PackageReference Include="System.Text.Json" Version="7.0.0-preview.1.22076.8" />
 		<PackageReference Include="Websocket.Client" Version="4.4.43" />

--- a/CatCoreStandaloneSandbox/CatCoreStandaloneSandbox.csproj
+++ b/CatCoreStandaloneSandbox/CatCoreStandaloneSandbox.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
       <PackageReference Include="System.Reactive" Version="5.0.0" />
-      <PackageReference Include="System.Text.Json" Version="6.0.2" />
+      <PackageReference Include="System.Text.Json" Version="7.0.0-preview.1.22076.8" />
       <PackageReference Include="Websocket.Client" Version="4.4.43" />
     </ItemGroup>
 

--- a/CatCoreStandaloneSandbox/CatCoreStandaloneSandbox.csproj
+++ b/CatCoreStandaloneSandbox/CatCoreStandaloneSandbox.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <LangVersion>9</LangVersion>
     </PropertyGroup>

--- a/CatCoreTests/CatCoreTests.csproj
+++ b/CatCoreTests/CatCoreTests.csproj
@@ -13,7 +13,7 @@
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
         <PackageReference Include="FluentAssertions" Version="6.5.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0-release-20220113-05" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0-preview-20220131-20" />
         <PackageReference Include="xunit" Version="2.4.2-pre.12" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
             <IncludeAssets>build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/CatCoreTests/CatCoreTests.csproj
+++ b/CatCoreTests/CatCoreTests.csproj
@@ -12,7 +12,7 @@
 			<IncludeAssets>build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-        <PackageReference Include="FluentAssertions" Version="6.4.0" />
+        <PackageReference Include="FluentAssertions" Version="6.5.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0-release-20220113-05" />
         <PackageReference Include="xunit" Version="2.4.2-pre.12" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
Updates several libraries to their latest version.
Also updated the CatCoreStandaloneSandbox TFM to .NET 6 due to compile-time deprecation of .NET 5 by the System.Runtime.CompilerServices.Unsafe library 