### PR TITLE
Added safeguard against ArgumentNullException caused by null channelName parameter

### DIFF
--- a/CatCore/Helpers/DictionaryExtensions.cs
+++ b/CatCore/Helpers/DictionaryExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Text;
+
+namespace CatCore.Helpers
+{
+	internal static class DictionaryExtensions
+	{
+		public static string ToPrettyString<TKey, TValue>(this IDictionary<TKey, TValue> dict)
+		{
+			var str = new StringBuilder();
+			str.Append("{ ");
+			foreach (var pair in dict)
+			{
+				str.Append($"{pair.Key}={pair.Value}; ");
+			}
+			str.Append('}');
+			return str.ToString();
+		}
+	}
+}

--- a/CatCore/Services/Twitch/TwitchIrcService.cs
+++ b/CatCore/Services/Twitch/TwitchIrcService.cs
@@ -368,7 +368,7 @@ namespace CatCore.Services.Twitch
 			{
 				_logger.Error("Couldn't properly handle incoming message due to null channelName. " +
 				              "Additional details: MessageMeta: {MessageMeta}; Prefix: {Prefix}; CommandType: {CommandType}; ChannelName: {ChannelName}; Message: {Message}",
-					messageMeta,
+					messageMeta?.ToPrettyString(),
 					prefix,
 					commandType,
 					channelName,


### PR DESCRIPTION
This will drop the message, but log the parameters at least for future investigation...

This was reported by Kinsi with the following stacktrace:
```csharp
ArgumentNullException: Value cannot be null.
Parameter name: key
  at System.Collections.Generic.Dictionary`2[TKey,TValue].FindEntry (TKey key) [0x00008] in <eae584ce26bc40229c1b1aa476bfa589>:0 
  at System.Collections.Generic.Dictionary`2[TKey,TValue].get_Item (TKey key) [0x00000] in <eae584ce26bc40229c1b1aa476bfa589>:0 
  at CatCore.Services.Twitch.TwitchIrcService.HandlePrivMessage (System.Collections.ObjectModel.ReadOnlyDictionary`2[System.String,System.String]& messageMeta, System.String& prefix, System.String& commandType, System.String& channelName, System.String& message, System.Boolean wasSendByLibrary) [0x00014] in <62c860a539574b419da07d8bf11bead6>:0 
  at CatCore.Services.Twitch.TwitchIrcService.HandleParsedIrcMessage (System.Collections.ObjectModel.ReadOnlyDictionary`2[System.String,System.String]& messageMeta, System.String& prefix, System.String& commandType, System.String& channelName, System.String& message, System.Boolean wasSendByLibrary) [0x002b2] in <62c860a539574b419da07d8bf11bead6>:0 
  at CatCore.Services.Twitch.TwitchIrcService.MessageReceivedHandlerInternal (System.String rawMessage, System.Boolean sendBySelf) [0x00053] in <62c860a539574b419da07d8bf11bead6>:0```