### PR TITLE
Bugfix/Fix portal api internal server error

### DIFF
--- a/CatCore/Models/Api/Responses/TwitchStateResponseDto.cs
+++ b/CatCore/Models/Api/Responses/TwitchStateResponseDto.cs
@@ -18,16 +18,16 @@ namespace CatCore.Models.Api.Responses
 		public bool ParseTwitchEmotes { get; }
 		public bool ParseCheermotes { get; }
 
-		public TwitchStateResponseDto(bool isValid, ValidationResponse? loggedInUser, List<UserData> channelData, TwitchConfig twitchConfig)
+		public TwitchStateResponseDto(bool isValid, ValidationResponse? loggedInUser, IEnumerable<UserData>? channelData, TwitchConfig twitchConfig)
 		{
 			LoggedIn = isValid;
 
 			OwnChannelEnabled = twitchConfig.OwnChannelEnabled;
-			ChannelData = channelData
+			ChannelData = channelData?
 				.Select(x => new TwitchChannelData(x.ProfileImageUrl, x.DisplayName, x.LoginName, x.UserId, x.LoginName == loggedInUser?.LoginName))
 				.OrderByDescending(channel => channel.IsSelf)
 				.ThenBy(channel => channel.DisplayName)
-				.ToList();
+				.ToList() ?? new List<TwitchChannelData>();
 
 			ParseBttvEmotes = twitchConfig.ParseBttvEmotes;
 			ParseFfzEmotes = twitchConfig.ParseFfzEmotes;

--- a/CatCore/Services/KittenApiService.cs
+++ b/CatCore/Services/KittenApiService.cs
@@ -180,7 +180,9 @@ namespace CatCore.Services
 					response.ContentType = "application/json";
 
 					var loggedInUserInfo = await _twitchAuthService.FetchLoggedInUserInfoWithRefresh().ConfigureAwait(false);
-					var userInfos = await _twitchChannelManagementService.GetAllChannelsEnriched().ConfigureAwait(false);
+					var userInfos = loggedInUserInfo != null
+						? await _twitchChannelManagementService.GetAllChannelsEnriched().ConfigureAwait(false)
+						: null;
 
 					await JsonSerializer
 						.SerializeAsync(response.OutputStream, new TwitchStateResponseDto(_twitchAuthService.TokenIsValid, loggedInUserInfo, userInfos, _settingsService.Config.TwitchConfig))

--- a/CatCore/Services/KittenApiService.cs
+++ b/CatCore/Services/KittenApiService.cs
@@ -131,15 +131,12 @@ namespace CatCore.Services
 
 		private Task<bool> HandleApiRequest(HttpListenerRequest request, HttpListenerResponse response)
 		{
-			switch (request.Url.Segments.ElementAtOrDefault(2))
+			return request.Url.Segments.ElementAtOrDefault(2) switch
 			{
-				case "twitch/":
-					return HandleTwitchApiRequests(request, response);
-				case "global/":
-					return HandleGlobalApiRequest(request, response);
-				default:
-					return Task.FromResult(false);
-			}
+				"twitch/" => HandleTwitchApiRequests(request, response),
+				"global/" => HandleGlobalApiRequest(request, response),
+				_ => Task.FromResult(false)
+			};
 		}
 
 		// ReSharper disable once CognitiveComplexity
@@ -158,6 +155,7 @@ namespace CatCore.Services
 						if (kvp[0] == "code")
 						{
 							code = kvp[1];
+							break;
 						}
 					}
 


### PR DESCRIPTION
When no credentials were present or the credentials couldn't be refreshed, the hitting the Twitch state endpoint would result in an Internal Server Error. This has now been fixed.