### PR TITLE
Reaching stable

### DIFF
--- a/CatCore.Shared/CatCore.Shared.csproj
+++ b/CatCore.Shared/CatCore.Shared.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="System.Text.Json" Version="7.0.0-preview.2.22152.2" />
+      <PackageReference Include="System.Text.Json" Version="7.0.0-preview.3.22175.4" />
     </ItemGroup>
 
 </Project>

--- a/CatCore/CatCore.csproj
+++ b/CatCore/CatCore.csproj
@@ -35,7 +35,7 @@
 		<PackageReference Include="Polly" Version="7.2.3" />
 		<PackageReference Include="Serilog" Version="2.11.0-dev-01380" />
 		<PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
-		<PackageReference Include="System.Net.Http.Json" Version="7.0.0-preview.2.22152.2" />
+		<PackageReference Include="System.Net.Http.Json" Version="7.0.0-preview.3.22175.4" />
 		<PackageReference Include="System.Reactive" Version="5.0.0" />
 		<PackageReference Include="System.Text.Json" Version="7.0.0-preview.3.22175.4" />
 		<PackageReference Include="WebsocketClientLite.PCL" Version="7.0.6" />

--- a/CatCore/CatCore.csproj
+++ b/CatCore/CatCore.csproj
@@ -30,7 +30,7 @@
 	</PropertyGroup>
 
     <ItemGroup>
-		<PackageReference Include="DryIoc.dll" Version="5.0.0" />
+		<PackageReference Include="DryIoc.dll" Version="5.0.1" />
 		<PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
 		<PackageReference Include="Polly" Version="7.2.3" />
 		<PackageReference Include="Serilog" Version="2.11.0-dev-01380" />

--- a/CatCore/CatCore.csproj
+++ b/CatCore/CatCore.csproj
@@ -31,7 +31,7 @@
 
     <ItemGroup>
 		<PackageReference Include="DryIoc.dll" Version="5.0.0" />
-		<PackageReference Include="JetBrains.Annotations" Version="2022.1.0-eap3" />
+		<PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
 		<PackageReference Include="Polly" Version="7.2.3" />
 		<PackageReference Include="Serilog" Version="2.11.0-dev-01380" />
 		<PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />

--- a/CatCore/CatCore.csproj
+++ b/CatCore/CatCore.csproj
@@ -37,7 +37,7 @@
 		<PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
 		<PackageReference Include="System.Net.Http.Json" Version="7.0.0-preview.2.22152.2" />
 		<PackageReference Include="System.Reactive" Version="5.0.0" />
-		<PackageReference Include="System.Text.Json" Version="7.0.0-preview.2.22152.2" />
+		<PackageReference Include="System.Text.Json" Version="7.0.0-preview.3.22175.4" />
 		<PackageReference Include="WebsocketClientLite.PCL" Version="7.0.6" />
     </ItemGroup>
 

--- a/CatCore/CatCore.csproj
+++ b/CatCore/CatCore.csproj
@@ -24,7 +24,7 @@
 		<Title>CatCore</Title>
 		<Description>CatCore is a .NET Standard 2.0 library which provides a shared connection to mods and other applications for Twitch (and other future streaming platforms).</Description>
 		<Authors>Eris</Authors>
-		<Version>0.0.1-alpha</Version>
+		<Version>1.0.0</Version>
 		<Copyright>Copyright © Eris 2022</Copyright>
 		<PackageProjectUrl>https://github.com/ErisApps/CatCore</PackageProjectUrl>
 	</PropertyGroup>

--- a/CatCore/Services/Interfaces/IKittenWebSocketProvider.cs
+++ b/CatCore/Services/Interfaces/IKittenWebSocketProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using CatCore.Helpers;
 
 namespace CatCore.Services.Interfaces

--- a/CatCore/Services/Twitch/TwitchAuthService.cs
+++ b/CatCore/Services/Twitch/TwitchAuthService.cs
@@ -38,7 +38,7 @@ namespace CatCore.Services.Twitch
 			"channel:manage:broadcast",
 			"channel:manage:polls",
 			"channel:manage:predictions",
-			"channel:read:redemptions",
+			"channel:manage:redemptions",
 			"channel:read:subscriptions"
 		};
 

--- a/CatCoreStandaloneSandbox/CatCoreStandaloneSandbox.csproj
+++ b/CatCoreStandaloneSandbox/CatCoreStandaloneSandbox.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
       <PackageReference Include="System.Reactive" Version="5.0.0" />
-      <PackageReference Include="System.Text.Json" Version="7.0.0-preview.2.22152.2" />
+      <PackageReference Include="System.Text.Json" Version="7.0.0-preview.3.22175.4" />
       <PackageReference Include="Websocket.Client" Version="4.4.43" />
     </ItemGroup>
 


### PR DESCRIPTION
The final changes for the very first release of CatCore
Changes are:
- Changing the authorization scope regarding redemptions
- Bumping dependencies one more time
- Bumping the library version to stable