### PR TITLE
Bugfix/Fix minor issues

### DIFF
--- a/CatCore/CatCoreInstance.cs
+++ b/CatCore/CatCoreInstance.cs
@@ -140,7 +140,6 @@ namespace CatCore
 			container.Register<TwitchBadgeDataProvider>(Reuse.Singleton);
 			container.Register<TwitchCheermoteDataProvider>(Reuse.Singleton);
 			container.Register<TwitchMediaDataProvider>(Reuse.Singleton);
-			container.RegisterInitializer<TwitchMediaDataProvider>(((provider, _) => provider.Initialize()));
 			container.Register<ITwitchIrcService, TwitchIrcService>(Reuse.Singleton);
 
 			container.RegisterMany(new[] { typeof(IPlatformService<ITwitchService, TwitchChannel, TwitchMessage>), typeof(ITwitchService) }, typeof(TwitchService), Reuse.Singleton,

--- a/CatCore/CatCoreInstance.cs
+++ b/CatCore/CatCoreInstance.cs
@@ -140,6 +140,7 @@ namespace CatCore
 			container.Register<TwitchBadgeDataProvider>(Reuse.Singleton);
 			container.Register<TwitchCheermoteDataProvider>(Reuse.Singleton);
 			container.Register<TwitchMediaDataProvider>(Reuse.Singleton);
+			container.Register<TwitchEmoteDetectionHelper>(Reuse.Singleton);
 			container.Register<ITwitchIrcService, TwitchIrcService>(Reuse.Singleton);
 
 			container.RegisterMany(new[] { typeof(IPlatformService<ITwitchService, TwitchChannel, TwitchMessage>), typeof(ITwitchService) }, typeof(TwitchService), Reuse.Singleton,

--- a/CatCore/Services/KittenBrowserLauncherService.cs
+++ b/CatCore/Services/KittenBrowserLauncherService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using CatCore.Services.Interfaces;
 
@@ -8,7 +9,21 @@ namespace CatCore.Services
 	{
 		public void LaunchWebPortal()
 		{
-			Task.Run(() => Process.Start(ConstantsBase.InternalApiServerUri));
+			Task.Run(() =>
+			{
+				if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+				{
+					Process.Start(ConstantsBase.InternalApiServerUri);
+				}
+				else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+				{
+					Process.Start("xdg-open", ConstantsBase.InternalApiServerUri);
+				}
+				else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+				{
+					Process.Start("open", ConstantsBase.InternalApiServerUri);
+				}
+			});
 		}
 	}
 }

--- a/CatCore/Services/Twitch/Interfaces/ITwitchAuthService.cs
+++ b/CatCore/Services/Twitch/Interfaces/ITwitchAuthService.cs
@@ -13,7 +13,7 @@ namespace CatCore.Services.Twitch.Interfaces
 
 		AuthenticationStatus Status { get; }
 		event Action? OnCredentialsChanged;
-		event Action? OnAuthenticationStatusChanged;
+		event Action<AuthenticationStatus>? OnAuthenticationStatusChanged;
 
 		ValidationResponse? FetchLoggedInUserInfo();
 		Task<ValidationResponse?> FetchLoggedInUserInfoWithRefresh();

--- a/CatCore/Services/Twitch/Media/BttvDataProvider.cs
+++ b/CatCore/Services/Twitch/Media/BttvDataProvider.cs
@@ -68,10 +68,13 @@ namespace CatCore.Services.Twitch.Media
 				var (success, bttvGlobalData) = await GetAsync(BTTV_API_BASEURL + "emotes/global", BttvSerializerContext.Default.IReadOnlyListBttvEmote).ConfigureAwait(false);
 				if (!success)
 				{
+					_logger.Warning("Something went wrong while trying to fetch the global BTTV emotes, the call was not successful");
 					return;
 				}
 
 				_globalBttvData = ParseBttvEmoteData(bttvGlobalData!, "BTTVGlobalEmote");
+
+				_logger.Debug("Finished caching {EmoteCount} global BTTV emotes", _globalBttvData.Count);
 			}
 			catch (Exception ex)
 			{
@@ -86,10 +89,13 @@ namespace CatCore.Services.Twitch.Media
 				var (success, bttvChannelData) = await GetAsync(BTTV_API_BASEURL + "users/twitch/" + userId, BttvSerializerContext.Default.BttvChannelData).ConfigureAwait(false);
 				if (!success)
 				{
+					_logger.Warning("Something went wrong while trying to fetch the BTTV channel emotes for channel {ChannelId}, the call was not successful", userId);
 					return;
 				}
 
 				_channelBttvData[userId] = ParseBttvEmoteData(bttvChannelData.ChannelEmotes.Concat<BttvEmoteBase>(bttvChannelData.SharedEmotes), "BTTVChannelEmote");
+
+				_logger.Debug("Finished caching {EmoteCount} BTTV channel emotes for channel {ChannelId}", _channelBttvData[userId].Count, userId);
 			}
 			catch (Exception ex)
 			{
@@ -105,6 +111,7 @@ namespace CatCore.Services.Twitch.Media
 					await GetAsync(BTTV_API_BASEURL + "frankerfacez/emotes/global", BttvSerializerContext.Default.IReadOnlyListFfzEmote).ConfigureAwait(false);
 				if (!success)
 				{
+					_logger.Warning("Something went wrong while trying to fetch the global FFZ emotes, the call was not successful");
 					return;
 				}
 
@@ -112,6 +119,8 @@ namespace CatCore.Services.Twitch.Media
 				{
 					_globalFfzData = ParseFfzEmoteData(ffzGlobalData!, "FFZGlobalEmote");
 				}
+
+				_logger.Debug("Finished caching {EmoteCount} global FFZ emotes", _globalFfzData.Count);
 			}
 			catch (Exception ex)
 			{
@@ -127,12 +136,19 @@ namespace CatCore.Services.Twitch.Media
 					await GetAsync(BTTV_API_BASEURL + "frankerfacez/users/twitch/" + userId, BttvSerializerContext.Default.IReadOnlyListFfzEmote).ConfigureAwait(false);
 				if (!success)
 				{
+					_logger.Warning("Something went wrong while trying to fetch the FFZ channel emotes for channel {ChannelId}, the call was not successful", userId);
 					return;
 				}
 
 				if (ffzChannelData!.Any())
 				{
 					_channelFfzData[userId] = ParseFfzEmoteData(ffzChannelData!, "FFZChannelEmote");
+
+					_logger.Debug("Finished caching {EmoteCount} FFZ channel emotes for channel {ChannelId}", _channelFfzData[userId].Count, userId);
+				}
+				else
+				{
+					_logger.Debug("No FFZ channel emotes found for channel {ChannelId}", userId);
 				}
 			}
 			catch (Exception ex)

--- a/CatCore/Services/Twitch/Media/TwitchEmoteDetectionHelper.cs
+++ b/CatCore/Services/Twitch/Media/TwitchEmoteDetectionHelper.cs
@@ -1,0 +1,210 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using CatCore.Models.Shared;
+using CatCore.Models.Twitch.IRC;
+using CatCore.Models.Twitch.Media;
+using CatCore.Services.Interfaces;
+
+namespace CatCore.Services.Twitch.Media
+{
+	internal class TwitchEmoteDetectionHelper
+	{
+		private readonly IKittenSettingsService _settingsService;
+		private readonly TwitchMediaDataProvider _twitchMediaDataProvider;
+
+		private static readonly Comparison<IChatEmote> EmojiComparison = (emote1, emote2) => emote1.StartIndex - emote2.StartIndex;
+
+		public TwitchEmoteDetectionHelper(
+			IKittenSettingsService settingsService,
+			TwitchMediaDataProvider twitchMediaDataProvider)
+		{
+			_settingsService = settingsService;
+			_twitchMediaDataProvider = twitchMediaDataProvider;
+		}
+
+		public List<IChatEmote> ExtractEmoteInfo(string message, IReadOnlyDictionary<string, string>? messageMeta, string channelId, uint bits)
+		{
+			var emotes = new List<IChatEmote>();
+
+			if (_settingsService.Config.GlobalConfig.HandleEmojis)
+			{
+				ExtractEmojis(emotes, message);
+			}
+
+			var twitchConfig = _settingsService.Config.TwitchConfig;
+			if (twitchConfig.ParseTwitchEmotes && messageMeta != null)
+			{
+				ExtractTwitchEmotes(emotes, message, messageMeta);
+			}
+
+			ExtractOtherEmotes(emotes, message, channelId, twitchConfig.ParseCheermotes && bits > 0, twitchConfig.ParseBttvEmotes || twitchConfig.ParseFfzEmotes);
+
+			return emotes;
+		}
+
+		private static void ExtractTwitchEmotes(List<IChatEmote> emotes, string message, IReadOnlyDictionary<string, string> messageMeta)
+		{
+			if (!messageMeta.TryGetValue(IrcMessageTags.EMOTES, out var emotesString))
+			{
+				return;
+			}
+
+			var twitchEmoteOffsetCorrectorHelper = new TwitchEmoteOffsetCorrectorHelper(message);
+
+			var emoteGroup = emotesString.Split('/');
+			for (var i = 0; i < emoteGroup.Length; i++)
+			{
+				var emoteSet = emoteGroup[i].Split(':');
+				var emoteId = emoteSet[0];
+
+				var prefixedEmoteId = "TwitchEmote_" + emoteId;
+
+				var emotePlaceholders = emoteSet[1].Split(',');
+
+				for (var j = 0; j < emotePlaceholders.Length; j++)
+				{
+					var emoteMeta = emotePlaceholders[j].Split('-');
+
+					var emoteStart = int.Parse(emoteMeta[0]);
+					var emoteEnd = int.Parse(emoteMeta[1]);
+					var emoteLength = emoteEnd - emoteStart + 1;
+
+					var offset = twitchEmoteOffsetCorrectorHelper.CalculateOffset(emoteStart);
+
+					emoteStart += offset;
+					emoteEnd += offset;
+
+					var messageSubstring = message.Substring(emoteStart, emoteLength);
+
+					var emoteUrl = $"https://static-cdn.jtvnw.net/emoticons/v2/{emoteId}/static/dark/3.0";
+
+					emotes.Add(new TwitchEmote(prefixedEmoteId, messageSubstring, emoteStart, emoteEnd, emoteUrl));
+				}
+			}
+		}
+
+		private static void ExtractEmojis(List<IChatEmote> emotes, string message)
+		{
+			for (var i = 0; i < message.Length; i++)
+			{
+				var foundEmojiLeaf = Emoji.Twemoji.Emojis.EmojiReferenceData.LookupLeaf(message, i);
+				if (foundEmojiLeaf != null)
+				{
+					emotes.Add(new Models.Shared.Emoji(foundEmojiLeaf.Key, foundEmojiLeaf.Key, i, i += foundEmojiLeaf.Depth, foundEmojiLeaf.Url));
+				}
+			}
+		}
+
+		// ReSharper disable once CognitiveComplexity
+		private void ExtractOtherEmotes(List<IChatEmote> emotes, string message, string channelId, bool parseCheermotes, bool parseCustomEmotes)
+		{
+			if (!parseCheermotes && !parseCustomEmotes)
+			{
+				return;
+			}
+
+			void ExtractOtherEmotesInternal(int messageStartIndex, int messageEndIndex)
+			{
+				var currentWordBuilder = new StringBuilder();
+				for (var i = messageStartIndex; i <= messageEndIndex; i++)
+				{
+					if (i == messageEndIndex || char.IsWhiteSpace(message[i]))
+					{
+						if (currentWordBuilder.Length <= 0)
+						{
+							continue;
+						}
+
+						var currentWord = currentWordBuilder.ToString();
+
+						if (parseCustomEmotes && _twitchMediaDataProvider.TryGetThirdPartyEmote(currentWord, channelId, out var customEmote))
+						{
+							var startIndex = i - currentWord.Length;
+							var endIndex = i - 1;
+
+							emotes.Add(new TwitchEmote(customEmote!.Id, customEmote.Name, startIndex, endIndex, customEmote.Url, customEmote.IsAnimated));
+						}
+						else if (parseCheermotes && _twitchMediaDataProvider.TryGetCheermote(currentWord, channelId, out var emoteBits, out var cheermoteData))
+						{
+							var startIndex = i - currentWord.Length;
+							var endIndex = i - 1;
+
+							emotes.Add(new TwitchEmote(cheermoteData!.Id, cheermoteData.Name, startIndex, endIndex, cheermoteData.Url, cheermoteData.IsAnimated, emoteBits, cheermoteData.Color));
+						}
+
+						currentWordBuilder.Clear();
+					}
+					else
+					{
+						currentWordBuilder.Append(message[i]);
+					}
+				}
+			}
+
+			var orderedEmotesList = emotes.OrderBy(x => x.StartIndex).ToList();
+			var loopStartIndex = 0;
+			foreach (var referenceEmote in orderedEmotesList)
+			{
+				ExtractOtherEmotesInternal(loopStartIndex, referenceEmote.StartIndex - 1);
+
+				loopStartIndex = referenceEmote.EndIndex + 2;
+			}
+
+			ExtractOtherEmotesInternal(loopStartIndex, message.Length);
+		}
+
+		/// <summary>
+		/// This helper is needed to calculate the correct offset for twitch emote indices when there are preceding surrogate pairs in the message,
+		/// as the Twitch treats a surrogate pair as a single character.
+		/// </summary>
+		private class TwitchEmoteOffsetCorrectorHelper
+		{
+			private readonly int[] _surrogatePairDescriptors;
+
+			private readonly bool _shouldNotCalculateOffset;
+
+			public TwitchEmoteOffsetCorrectorHelper(string message)
+			{
+				_surrogatePairDescriptors = CalculateSurrogatePairInfo(message).ToArray();
+
+				_shouldNotCalculateOffset = _surrogatePairDescriptors.Length == 0;
+			}
+
+			public int CalculateOffset(int startIndex)
+			{
+				if (_shouldNotCalculateOffset)
+				{
+					return 0;
+				}
+
+				var offset = 0;
+				for (var i = 0; i < _surrogatePairDescriptors.Length; i++)
+				{
+					var surrogatePairStartIndex = _surrogatePairDescriptors[i];
+					if (startIndex < surrogatePairStartIndex)
+					{
+						break;
+					}
+
+					offset++;
+					startIndex++;
+				}
+
+				return offset;
+			}
+
+			private static IEnumerable<int> CalculateSurrogatePairInfo(string message)
+			{
+				for (var i = 0; i < message.Length; i += 2)
+				{
+					if (char.IsSurrogate(message[i]))
+					{
+						yield return i;
+					}
+				}
+			}
+		}
+	}
+}

--- a/CatCore/Services/Twitch/Media/TwitchEmoteDetectionHelper.cs
+++ b/CatCore/Services/Twitch/Media/TwitchEmoteDetectionHelper.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using CatCore.Models.Shared;
@@ -26,15 +25,15 @@ namespace CatCore.Services.Twitch.Media
 		{
 			var emotes = new List<IChatEmote>();
 
-			if (_settingsService.Config.GlobalConfig.HandleEmojis)
-			{
-				ExtractEmojis(emotes, message);
-			}
-
 			var twitchConfig = _settingsService.Config.TwitchConfig;
 			if (twitchConfig.ParseTwitchEmotes && messageMeta != null)
 			{
 				ExtractTwitchEmotes(emotes, message, messageMeta);
+			}
+
+			if (_settingsService.Config.GlobalConfig.HandleEmojis)
+			{
+				ExtractEmojis(emotes, message);
 			}
 
 			ExtractOtherEmotes(emotes, message, channelId, twitchConfig.ParseCheermotes && bits > 0, twitchConfig.ParseBttvEmotes || twitchConfig.ParseFfzEmotes);

--- a/CatCore/Services/Twitch/Media/TwitchEmoteDetectionHelper.cs
+++ b/CatCore/Services/Twitch/Media/TwitchEmoteDetectionHelper.cs
@@ -14,8 +14,6 @@ namespace CatCore.Services.Twitch.Media
 		private readonly IKittenSettingsService _settingsService;
 		private readonly TwitchMediaDataProvider _twitchMediaDataProvider;
 
-		private static readonly Comparison<IChatEmote> EmojiComparison = (emote1, emote2) => emote1.StartIndex - emote2.StartIndex;
-
 		public TwitchEmoteDetectionHelper(
 			IKittenSettingsService settingsService,
 			TwitchMediaDataProvider twitchMediaDataProvider)

--- a/CatCore/Services/Twitch/TwitchAuthService.cs
+++ b/CatCore/Services/Twitch/TwitchAuthService.cs
@@ -231,11 +231,11 @@ namespace CatCore.Services.Twitch
 			}
 
 			var validationResponse = await responseMessage.Content.ReadFromJsonAsync(TwitchAuthSerializerContext.Default.ValidationResponse).ConfigureAwait(false);
+			_loggedInUser = validationResponse;
+
 			UpdateCredentials(credentials.ValidUntil!.Value > validationResponse.ExpiresIn
 				? new TwitchCredentials(credentials.AccessToken, credentials.RefreshToken, validationResponse.ExpiresIn)
 				: credentials);
-
-			_loggedInUser = validationResponse;
 
 			Status = AuthenticationStatus.Authenticated;
 

--- a/CatCore/Services/Twitch/TwitchAuthService.cs
+++ b/CatCore/Services/Twitch/TwitchAuthService.cs
@@ -72,11 +72,11 @@ namespace CatCore.Services.Twitch
 				}
 
 				_status = value;
-				OnAuthenticationStatusChanged?.Invoke();
+				OnAuthenticationStatusChanged?.Invoke(_status);
 			}
 		}
 
-		public event Action? OnAuthenticationStatusChanged;
+		public event Action<AuthenticationStatus>? OnAuthenticationStatusChanged;
 
 		public TwitchAuthService(ILogger logger, IKittenPathProvider kittenPathProvider, ConstantsBase constants, Version libraryVersion) : base(logger, kittenPathProvider)
 		{

--- a/CatCore/Services/Twitch/TwitchService.cs
+++ b/CatCore/Services/Twitch/TwitchService.cs
@@ -132,7 +132,7 @@ namespace CatCore.Services.Twitch
 			_twitchIrcService.OnChatCleared -= TwitchIrcServiceOnChatCleared;
 		}
 
-		private void TwitchAuthServiceOnAuthenticatedStatusChanged()
+		private void TwitchAuthServiceOnAuthenticatedStatusChanged(AuthenticationStatus _)
 		{
 			OnAuthenticatedStateChanged?.Invoke(this);
 		}

--- a/CatCore/Services/Twitch/TwitchService.cs
+++ b/CatCore/Services/Twitch/TwitchService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using CatCore.Models.Credentials;
 using CatCore.Models.Twitch;
 using CatCore.Models.Twitch.IRC;
 using CatCore.Services.Interfaces;
@@ -107,7 +108,7 @@ namespace CatCore.Services.Twitch
 		{
 			DeregisterInternalEventHandlers();
 
-			_twitchAuthService.OnCredentialsChanged += TwitchAuthServiceOnAuthenticatedStatusChanged;
+			_twitchAuthService.OnAuthenticationStatusChanged += TwitchAuthServiceOnAuthenticatedStatusChanged;
 
 			_twitchIrcService.OnChatConnected += TwitchIrcServiceOnChatConnected;
 			_twitchIrcService.OnJoinChannel += TwitchIrcServiceOnJoinChannel;


### PR DESCRIPTION
This PR fixes a few minor bugs, including (but not limited to):
- BTTV/FFZ emotes and such not being cached for detection during startup for own channel
- ValidationResponse being set too late after token refresh
- CatCore portal not being opened on MacOS/Unix
- Twitch emote indices possibly being off by 1 or more if there were preceding Unicode emojis in the message.